### PR TITLE
Contract test input, null check prior to getTags(), and NotUpdatable check

### DIFF
--- a/aws-organizations-organizationalunit/inputs/inputs_1_create.json
+++ b/aws-organizations-organizationalunit/inputs/inputs_1_create.json
@@ -1,0 +1,10 @@
+{
+  "Name": "testOU1",
+  "ParentId": "{{orgRootId}}",
+  "Tags": [
+    {
+        "Key": "key1",
+        "Value": "value1"
+    }
+  ]
+}

--- a/aws-organizations-organizationalunit/inputs/inputs_1_update.json
+++ b/aws-organizations-organizationalunit/inputs/inputs_1_update.json
@@ -1,0 +1,9 @@
+{
+  "Name": "testOUUpdatedName",
+  "Tags": [
+    {
+        "Key": "updatedKey",
+        "Value": "updatedValue"
+    }
+  ]
+}

--- a/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/UpdateHandlerTest.java
+++ b/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/UpdateHandlerTest.java
@@ -145,6 +145,32 @@ public class UpdateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void handleRequest_withNullPreviousModel_Success() {
+        final ResourceModel model = generateUpdatedResourceModel();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+            .previousResourceState(null)
+            .desiredResourceState(model)
+            .build();
+
+        final UpdateOrganizationalUnitResponse updateOrganizationalUnitResponse = getUpdateOrganizationalUnitResponse();
+        final DescribeOrganizationalUnitResponse describeOrganizationalUnitResponse = getDescribeOrganizationalUnitResponse();
+        final ListParentsResponse listParentsResponse = getListParentsResponse();
+        final ListTagsForResourceResponse listTagsForResourceResponse = TagTestResourcesHelper.buildEmptyTagsResponse();
+
+        when(mockProxyClient.client().updateOrganizationalUnit(any(UpdateOrganizationalUnitRequest.class))).thenReturn(updateOrganizationalUnitResponse);
+        when(mockProxyClient.client().describeOrganizationalUnit(any(DescribeOrganizationalUnitRequest.class))).thenReturn(describeOrganizationalUnitResponse);
+        when(mockProxyClient.client().listParents(any(ListParentsRequest.class))).thenReturn(listParentsResponse);
+        when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsForResourceResponse);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = updateHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(false), mockProxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getResourceModels()).isNull();
+    }
+
+    @Test
     public void handleRequest_Fails_With_CfnNotFoundException() {
         final ResourceModel previousResourceModel = ResourceModel.builder()
             .name(TEST_OU_NAME)


### PR DESCRIPTION
*Description of changes:*

- Added contract test input
- Added null check prior to calling getTags() to avoid NPE
- Check that the previousModel OU id is equal to the desiredModel OU id. If not then return NotUpdatable exception
    - Added unit test for this check as well

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
