### PR TITLE
Set ParentId to be a createOnly property

### DIFF
--- a/aws-organizations-organizationalunit/aws-organizations-organizationalunit.json
+++ b/aws-organizations-organizationalunit/aws-organizations-organizationalunit.json
@@ -105,6 +105,9 @@
     "cloudFormationSystemTags": false,
     "tagProperty": "/properties/Tags"
   },
+  "createOnlyProperties": [
+    "/properties/ParentId"
+  ],
   "readOnlyProperties": [
     "/properties/Arn",
     "/properties/Id"

--- a/aws-organizations-organizationalunit/docs/README.md
+++ b/aws-organizations-organizationalunit/docs/README.md
@@ -60,7 +60,7 @@ _Maximum_: <code>100</code>
 
 _Pattern_: <code>^(r-[0-9a-z]{4,32})|(ou-[0-9a-z]{4,32}-[a-z0-9]{8,32})$</code>
 
-_Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-no-interrupt)
+_Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 
 #### Tags
 


### PR DESCRIPTION
*Description of changes:*
Setting ParentId to be a createOnly property. This will allow us to update the parentId of an OU if it is "empty" (no child OUs or accounts).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
