### PR TITLE
update error translation for PolicyInUseException for policy resource…

### DIFF
--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/BaseHandlerStd.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/BaseHandlerStd.java
@@ -64,9 +64,7 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         final Logger logger
     ) {
         HandlerErrorCode errorCode = HandlerErrorCode.GeneralServiceException;
-        if (e instanceof PolicyInUseException) {
-            errorCode = HandlerErrorCode.GeneralServiceException;
-        } else if (e instanceof DuplicatePolicyException || e instanceof DuplicatePolicyAttachmentException) {
+        if (e instanceof DuplicatePolicyException || e instanceof DuplicatePolicyAttachmentException) {
             errorCode = HandlerErrorCode.AlreadyExists;
         } else if (e instanceof AwsOrganizationsNotInUseException || e instanceof PolicyNotFoundException
             || e instanceof TargetNotFoundException || e instanceof PolicyNotAttachedException) {
@@ -78,7 +76,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         } else if (e instanceof ConstraintViolationException) {
             errorCode = HandlerErrorCode.ServiceLimitExceeded;
         } else if (e instanceof InvalidInputException || e instanceof MalformedPolicyDocumentException
-            || e instanceof PolicyTypeNotAvailableForOrganizationException || e instanceof PolicyTypeNotEnabledException) {
+            || e instanceof PolicyTypeNotAvailableForOrganizationException || e instanceof PolicyTypeNotEnabledException
+            || e instanceof PolicyInUseException) {
             errorCode = HandlerErrorCode.InvalidRequest;
         } else if (e instanceof ServiceException) {
             errorCode = HandlerErrorCode.ServiceInternalError;

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/DeleteHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/DeleteHandlerTest.java
@@ -234,7 +234,7 @@ public class DeleteHandlerTest extends AbstractTestBase {
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getResourceModels()).isNull();
-        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.GeneralServiceException);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
 
         verify(mockOrgsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(mockOrgsClient);


### PR DESCRIPTION
update error translation for PolicyInUseException for policy resource type

Since this is a valid scenario for a user which they can and should handle on their end, we should map to something other than `GeneralServiceException`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
