### PR TITLE
add retry in policy delete handler and edit logging

### DIFF
--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/BaseHandlerStd.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/BaseHandlerStd.java
@@ -91,7 +91,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         } else if (e instanceof TooManyRequestsException) {
           errorCode = HandlerErrorCode.Throttling;
         }
-        logger.log(String.format("[Exception] Failed with exception: [%s]. Message: %s, ", e.getClass().getSimpleName(), e.getMessage()));
+        logger.log(String.format("[Exception] Failed with exception: [%s]. Message: [%s], ErrorCode: [%s] for OrganizationalUnit [%s].",
+            e.getClass().getSimpleName(), e.getMessage(), errorCode, resourceModel.getName()));
 
         return ProgressEvent.failed(resourceModel, callbackContext, errorCode, e.getMessage());
     }

--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/CreateHandler.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/CreateHandler.java
@@ -42,7 +42,7 @@ public class CreateHandler extends BaseHandlerStd {
     }
 
     protected CreateOrganizationalUnitResponse createOrganizationalUnit(final CreateOrganizationalUnitRequest createOrganizationalUnitRequest, final ProxyClient<OrganizationsClient> orgsClient) {
-        log.log("Calling createOrganizationalUnit API.");
+        log.log(String.format("Calling createOrganizationalUnit API for OU [%s].", createOrganizationalUnitRequest.name()));
         final CreateOrganizationalUnitResponse createOrganizationalUnitResponse = orgsClient.injectCredentialsAndInvokeV2(createOrganizationalUnitRequest, orgsClient.client()::createOrganizationalUnit);
         return createOrganizationalUnitResponse;
     }

--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/DeleteHandler.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/DeleteHandler.java
@@ -38,7 +38,7 @@ public class DeleteHandler extends BaseHandlerStd {
     }
 
     protected DeleteOrganizationalUnitResponse deleteOrganizationalUnit(final DeleteOrganizationalUnitRequest deleteOrganizationalUnitRequest, final ProxyClient<OrganizationsClient> orgsClient) {
-        log.log("Calling deleteOrganizationalUnit API.");
+        log.log(String.format("Calling deleteOrganizationalUnit API for OU [%s].", deleteOrganizationalUnitRequest.organizationalUnitId()));
         final DeleteOrganizationalUnitResponse deleteOrganizationalUnitResponse = orgsClient.injectCredentialsAndInvokeV2(deleteOrganizationalUnitRequest, orgsClient.client()::deleteOrganizationalUnit);
         return deleteOrganizationalUnitResponse;
     }

--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/ReadHandler.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/ReadHandler.java
@@ -92,21 +92,21 @@ public class ReadHandler extends BaseHandlerStd {
     }
 
     protected DescribeOrganizationalUnitResponse describeOrganizationalUnit(final DescribeOrganizationalUnitRequest describeOrganizationalUnitRequest, final ProxyClient<OrganizationsClient> orgsClient) {
-        log.log("Calling describeOrganizationalUnit API.");
+        log.log(String.format("Calling describeOrganizationalUnit API for OU [%s].", describeOrganizationalUnitRequest.organizationalUnitId()));
         final DescribeOrganizationalUnitResponse describeOrganizationalUnitResponse = orgsClient.injectCredentialsAndInvokeV2(describeOrganizationalUnitRequest, orgsClient.client()::describeOrganizationalUnit);
         return describeOrganizationalUnitResponse;
     }
 
     // DescribeOU call doesn't return tags on OU so ListTags call needs to be made separately
     protected ListTagsForResourceResponse listTagsForResource(final ListTagsForResourceRequest listTagsForResourceRequest, final ProxyClient<OrganizationsClient> orgsClient) {
-        log.log("Calling listTagsForResource API.");
+        log.log(String.format("Calling listTagsForResource API for resource [%s].", listTagsForResourceRequest.resourceId()));
         final ListTagsForResourceResponse listTagsForResourceResponse = orgsClient.injectCredentialsAndInvokeV2(listTagsForResourceRequest, orgsClient.client()::listTagsForResource);
         return listTagsForResourceResponse;
     }
 
     // DescribeOU call doesn't return parentId of OU so ListParents call needs to be made separately
     protected ListParentsResponse listParents(final ListParentsRequest listParentsRequest, final ProxyClient<OrganizationsClient> orgsClient) {
-        log.log("Calling listParents API.");
+        log.log(String.format("Calling listParents API for OU [%s].", listParentsRequest.childId()));
         final ListParentsResponse listParentsResponse = orgsClient.injectCredentialsAndInvokeV2(listParentsRequest, orgsClient.client()::listParents);
         return listParentsResponse;
     }

--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/UpdateHandler.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/UpdateHandler.java
@@ -43,7 +43,7 @@ public class UpdateHandler extends BaseHandlerStd {
         if (previousModel != null) {
             if (previousModel.getId() != null && !ouId.equals(previousModel.getId())) {
                 return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.NotUpdatable,
-                    "Organizational unit cannot be updated as the id was changed");
+                    String.format("Organizational unit [%s] cannot be updated as the id was changed", name));
             }
         }
 
@@ -67,7 +67,7 @@ public class UpdateHandler extends BaseHandlerStd {
     }
 
     protected UpdateOrganizationalUnitResponse updateOrganizationalUnit(final UpdateOrganizationalUnitRequest updateOrganizationalUnitRequest, final ProxyClient<OrganizationsClient> orgsClient) {
-        log.log("Calling updateOrganizationalUnit API.");
+        log.log(String.format("Calling updateOrganizationalUnit API for OU [%s].", updateOrganizationalUnitRequest.organizationalUnitId()));
         final UpdateOrganizationalUnitResponse updateOrganizationalUnitResponse = orgsClient.injectCredentialsAndInvokeV2(updateOrganizationalUnitRequest, orgsClient.client()::updateOrganizationalUnit);
         return updateOrganizationalUnitResponse;
     }
@@ -96,7 +96,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
         // Delete tags only if tagsToRemove is not empty
         if (!CollectionUtils.isNullOrEmpty(tagsToRemove)) {
-            logger.log("Calling untagResource API.");
+            logger.log(String.format("Calling untagResource API for OU [%s].", model.getName()));
             UntagResourceRequest untagResourceRequest = Translator.translateToUntagResourceRequest(tagsToRemove, organizationalUnitId);
             try {
                 awsClientProxy.injectCredentialsAndInvokeV2(untagResourceRequest, orgsClient.client()::untagResource);
@@ -107,7 +107,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
         // Add tags only if tagsToAddOrUpdate is not empty.
         if (!CollectionUtils.isNullOrEmpty(tagsToAddOrUpdate)) {
-            logger.log("Calling tagResource API.");
+            logger.log(String.format("Calling tagResource API for OU [%s].", model.getName()));
             TagResourceRequest tagResourceRequest = Translator.translateToTagResourceRequest(tagsToAddOrUpdate, organizationalUnitId);
             try {
                 awsClientProxy.injectCredentialsAndInvokeV2(tagResourceRequest, orgsClient.client()::tagResource);

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/CallbackContext.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/CallbackContext.java
@@ -9,6 +9,10 @@ import software.amazon.cloudformation.proxy.StdCallbackContext;
 public class CallbackContext extends StdCallbackContext {
     private int maxRetryCount = 3;
     // used in CREATE handler re-invoking
-    private int retryAttempt = 0;
+    private int retryAttachAttempt = 0;
     private boolean isPolicyCreated = false;
+    // used in DELETE handler re-invoking
+    private int retryDetachAttempt = 0;
+    private int retryDeleteAttempt = 0;
+    private boolean isPolicyDetached = false;
 }

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/DeleteHandler.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/DeleteHandler.java
@@ -9,8 +9,8 @@ import software.amazon.awssdk.services.organizations.model.PolicyNotAttachedExce
 import software.amazon.awssdk.services.organizations.model.TargetNotFoundException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Logger;
-import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.OperationStatus;
+import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
@@ -28,24 +28,45 @@ public class DeleteHandler extends BaseHandlerStd {
 
         this.log = logger;
         final ResourceModel model = request.getDesiredResourceState();
-        logger.log(String.format("Entered %s delete handler with policy Id: [%s]", ResourceModel.TYPE_NAME, model.getId()));
+        logger.log(String.format("Entered %s delete handler with policy Id: [%s], policy name: [%s].", ResourceModel.TYPE_NAME, model.getId(), model.getName()));
 
         return ProgressEvent.progress(model, callbackContext)
             .then(progress -> detachPolicyFromTargets(awsClientProxy, request, model, callbackContext, orgsClient, logger))
-            .then(progress ->
-                awsClientProxy.initiate("AWS-Organizations-Policy::DeletePolicy", orgsClient, model, progress.getCallbackContext())
-                    .translateToServiceRequest(t -> Translator.translateToDeleteRequest(model))
-                    .makeServiceCall(this::deletePolicy)
-                    .handleError((organizationsRequest, e, proxyClient1, model1, context) -> handleError(
-                        organizationsRequest, e, proxyClient1, model1, context, logger))
-                    .done((deleteRequest) -> ProgressEvent.<ResourceModel, CallbackContext>builder().status(OperationStatus.SUCCESS).build()));
-
+            .then(progress -> deletePolicyProcess(awsClientProxy, request, model, callbackContext, orgsClient, logger));
     }
 
     protected DeletePolicyResponse deletePolicy(final DeletePolicyRequest deletePolicyRequest, final ProxyClient<OrganizationsClient> orgsClient) {
-        log.log(String.format("Attempt to delete policy."));
+        log.log(String.format("Attempt to delete policy for [%s].", deletePolicyRequest.policyId()));
         final DeletePolicyResponse deletePolicyResponse = orgsClient.injectCredentialsAndInvokeV2(deletePolicyRequest, orgsClient.client()::deletePolicy);
         return deletePolicyResponse;
+    }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> deletePolicyProcess(
+        final AmazonWebServicesClientProxy awsClientProxy,
+        final ResourceHandlerRequest<ResourceModel> request,
+        final ResourceModel model,
+        final CallbackContext callbackContext,
+        final ProxyClient<OrganizationsClient> orgsClient,
+        final Logger logger
+    ){
+        final ProgressEvent<ResourceModel, CallbackContext> progressEvent = awsClientProxy
+            .initiate("AWS-Organizations-Policy::DeletePolicy", orgsClient, model, callbackContext)
+            .translateToServiceRequest((resourceModel) -> Translator.translateToDeleteRequest(model))
+            .makeServiceCall(this::deletePolicy)
+            .handleError((organizationsRequest, e, proxyClient1, model1, context) -> {
+                // retry on exceptions that map to CloudFormation retriable exceptions
+                // reference: https://docs.aws.amazon.com/cloudformation-cli/latest/userguide/resource-type-test-contract-errors.html
+                if (isRetriableException(e)) {
+                    return handleRetriableException(organizationsRequest, proxyClient1, context, logger, e, model1, PolicyConstants.Action.DELETE_POLICY);
+                } else {
+                    return handleError(organizationsRequest, e, proxyClient1, model1, context, logger);
+                }
+            })
+            .success();
+
+        if (!progressEvent.isSuccess()) { return progressEvent; }
+
+        return ProgressEvent.<ResourceModel, CallbackContext>builder().status(OperationStatus.SUCCESS).build();
     }
 
     protected ProgressEvent<ResourceModel, CallbackContext> detachPolicyFromTargets(
@@ -57,13 +78,18 @@ public class DeleteHandler extends BaseHandlerStd {
         final Logger logger) {
 
         Set<String> targets = model.getTargetIds();
+        String policyName = model.getName();
         if (CollectionUtils.isEmpty(targets)) {
-            logger.log("No target id found in request. Skip detaching policy.");
+            logger.log(String.format("No target id found in request. Skip detaching policy for [%s].", policyName));
             return ProgressEvent.progress(model, callbackContext);
         }
-        logger.log("Target Ids found in request. Start detaching policy to provided targets.");
+        if (callbackContext.isPolicyDetached()){
+            logger.log(String.format("All policy detached from previous invoke. Skip to delete policy for policy [%s].", policyName));
+            return ProgressEvent.progress(model, callbackContext);
+        }
+        logger.log(String.format("Target Ids found in request for policy [%s]. Start detaching policy to provided targets.", policyName));
         for (final String targetId : targets) {
-            logger.log(String.format("Start detaching policy from targetId [%s].", targetId));
+            logger.log(String.format("Start detaching policy from targetId [%s] for policy [%s].", targetId, policyName));
             DetachPolicyRequest detachPolicyRequest = Translator.translateToDetachRequest(model.getId(), targetId);
             try {
                 awsClientProxy.injectCredentialsAndInvokeV2(detachPolicyRequest, orgsClient.client()::detachPolicy);
@@ -72,11 +98,15 @@ public class DeleteHandler extends BaseHandlerStd {
                     logger.log(String.format("Got %s when calling detachPolicy for "
                         + "policyId [%s], targetId [%s]. Continuing with delete...",
                         e.getClass().getName(), model.getId(), targetId));
-                } else {
+                } else if (isRetriableException(e)) {
+                    return handleRetriableException(detachPolicyRequest, orgsClient, callbackContext, logger, e, model, PolicyConstants.Action.DETACH_POLICY);
+                }
+                else {
                     return handleError(detachPolicyRequest, e, orgsClient, model, callbackContext, logger);
                 }
             }
         }
+        callbackContext.setPolicyDetached(true);
         return ProgressEvent.progress(model, callbackContext);
     }
 }

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/PolicyConstants.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/PolicyConstants.java
@@ -19,4 +19,11 @@ public class PolicyConstants {
             return policyType;
         }
     }
+
+    // constants used for handleRetriableException
+    public enum Action {
+        ATTACH_POLICY,
+        DETACH_POLICY,
+        DELETE_POLICY
+    }
 }

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/ReadHandler.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/ReadHandler.java
@@ -53,7 +53,7 @@ public class ReadHandler extends BaseHandlerStd {
     }
 
     protected DescribePolicyResponse describePolicy(final DescribePolicyRequest describePolicyRequest, final ProxyClient<OrganizationsClient> orgsClient) {
-        log.log(String.format("Retrieving policy details."));
+        log.log(String.format("Retrieving policy details for policy [%s].", describePolicyRequest.policyId()));
         final DescribePolicyResponse response = orgsClient.injectCredentialsAndInvokeV2(describePolicyRequest, orgsClient.client()::describePolicy);
         return response;
     }
@@ -119,7 +119,7 @@ public class ReadHandler extends BaseHandlerStd {
     }
 
     protected ListTagsForResourceResponse listTagsForResource(final ListTagsForResourceRequest listTagsForResourceRequest, final ProxyClient<OrganizationsClient> orgsClient) {
-        log.log("Calling listTagsForResource API.");
+        log.log(String.format("Calling listTagsForResource API for policy [%s].", listTagsForResourceRequest.resourceId()));
         final ListTagsForResourceResponse response = orgsClient.injectCredentialsAndInvokeV2(listTagsForResourceRequest, orgsClient.client()::listTagsForResource);
         return response;
     }

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/UpdateHandler.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/UpdateHandler.java
@@ -45,12 +45,12 @@ public class UpdateHandler extends BaseHandlerStd {
 
         if (previousModel == null || previousModel.getId() == null || !policyId.equals(previousModel.getId())) {
             return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.NotFound,
-                "Policy cannot be updated as the id was changed!");
+                String.format("Policy [%s] cannot be updated as the id was changed!", model.getName()));
         }
 
         if (!previousModel.getType().equalsIgnoreCase(model.getType())) {
             return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.NotUpdatable,
-                "Cannot update policy type after creation!");
+                String.format("Cannot update policy type after creation for [%s]!", model.getName()));
         }
 
         // call UpdatePolicy API
@@ -70,7 +70,7 @@ public class UpdateHandler extends BaseHandlerStd {
     }
 
     protected UpdatePolicyResponse updatePolicy(final UpdatePolicyRequest updatePolicyRequest, final ProxyClient<OrganizationsClient> orgsClient) {
-        log.log("Calling updatePolicy API.");
+        log.log(String.format("Calling updatePolicy API for policy [%s].", updatePolicyRequest.policyId()));
         final UpdatePolicyResponse response = orgsClient.injectCredentialsAndInvokeV2(updatePolicyRequest, orgsClient.client()::updatePolicy);
         return response;
     }
@@ -109,7 +109,7 @@ public class UpdateHandler extends BaseHandlerStd {
         // make the calls to attach to new targets
         if (!CollectionUtils.isNullOrEmpty(targetsToAttach)) {
             for (String attachTargetId : targetsToAttach) {
-                logger.log(String.format("Calling attachPolicy API with targetId: [%s]", attachTargetId));
+                logger.log(String.format("Calling attachPolicy API with targetId: [%s] for policy [%s]", attachTargetId, model.getName()));
                 AttachPolicyRequest attachPolicyRequest = Translator.translateToAttachRequest(policyId, attachTargetId);
                 try {
                     awsClientProxy.injectCredentialsAndInvokeV2(attachPolicyRequest, orgsClient.client()::attachPolicy);
@@ -128,7 +128,7 @@ public class UpdateHandler extends BaseHandlerStd {
         // make calls to detach from old targets
         if (!CollectionUtils.isNullOrEmpty(targetsToRemove)) {
             for (String removeTargetId : targetsToRemove) {
-                logger.log(String.format("Calling detachPolicy API with targetId: [%s]", removeTargetId));
+                logger.log(String.format("Calling detachPolicy API with targetId: [%s] for policy [%s]", removeTargetId, model.getName()));
                 DetachPolicyRequest detachPolicyRequest = Translator.translateToDetachRequest(policyId, removeTargetId);
                 try {
                     awsClientProxy.injectCredentialsAndInvokeV2(detachPolicyRequest, orgsClient.client()::detachPolicy);
@@ -172,7 +172,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
         // Delete tags only if tagsToRemove is not empty
         if (!CollectionUtils.isNullOrEmpty(tagsToRemove)) {
-            logger.log("Calling untagResource API.");
+            logger.log(String.format("Calling untagResource API for policy [%s].", model.getName()));
             UntagResourceRequest untagResourceRequest = Translator.translateToUntagResourceRequest(tagsToRemove, policyId);
             try {
                 awsClientProxy.injectCredentialsAndInvokeV2(untagResourceRequest, orgsClient.client()::untagResource);
@@ -183,7 +183,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
         // Add tags only if tagsToAddOrUpdate is not empty.
         if (!CollectionUtils.isNullOrEmpty(tagsToAddOrUpdate)) {
-            logger.log("Calling tagResource API.");
+            logger.log(String.format("Calling tagResource API for policy [%s].", model.getName()));
             TagResourceRequest tagResourceRequest = Translator.translateToTagResourceRequest(tagsToAddOrUpdate, policyId);
             try {
                 awsClientProxy.injectCredentialsAndInvokeV2(tagResourceRequest, orgsClient.client()::tagResource);

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
@@ -249,19 +249,19 @@ public class CreateHandlerTest extends AbstractTestBase {
         ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, context, mockProxyClient, logger);
         // retry attempt 1
         assertThat(context.isPolicyCreated()).isEqualTo(true);
-        assertThat(context.getRetryAttempt()).isEqualTo(1);
+        assertThat(context.getRetryAttachAttempt()).isEqualTo(1);
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isGreaterThan(0);
         // retry attempt 2
         response = createHandler.handleRequest(mockAwsClientProxy, request, context, mockProxyClient, logger);
         assertThat(context.isPolicyCreated()).isEqualTo(true);
-        assertThat(context.getRetryAttempt()).isEqualTo(2);
+        assertThat(context.getRetryAttachAttempt()).isEqualTo(2);
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isGreaterThan(0);
         // retry attempt 3
         response = createHandler.handleRequest(mockAwsClientProxy, request, context, mockProxyClient, logger);
         assertThat(context.isPolicyCreated()).isEqualTo(true);
-        assertThat(context.getRetryAttempt()).isEqualTo(3);
+        assertThat(context.getRetryAttachAttempt()).isEqualTo(3);
         assertThat(response.getStatus()).isEqualTo(OperationStatus.IN_PROGRESS);
         assertThat(response.getCallbackDelaySeconds()).isGreaterThan(0);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
**AWS::Organizations::OrganizationalUnit**

1. changed logging message to include OU info, in case of concurrent creation, it becomes hard to understand which OU this message is referring to in log

**AWS::Organizations::Policy**

1. changed logging message to include Policy info, same as above
2. added extra retry in detachPolicy and deletePolicy call and unit test

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
