### PR TITLE
Fix for returning the correct Progress Event status for the READ/LIST handlers

### DIFF
--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/BaseHandlerStd.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/BaseHandlerStd.java
@@ -1,7 +1,6 @@
 package software.amazon.organizations.account;
 
 import software.amazon.awssdk.core.exception.RetryableException;
-import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import software.amazon.awssdk.services.organizations.model.AccessDeniedException;
 import software.amazon.awssdk.services.organizations.model.AccessDeniedForDependencyException;
@@ -192,10 +191,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             int currentAttempt = context.getCurrentRetryAttempt(actionName, handlerName);
             if (currentAttempt < MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION) {
                 context.setCurrentRetryAttempt(actionName, handlerName);
-                if (actionName == AccountConstants.Action.LIST_PARENTS
-                        || actionName == AccountConstants.Action.LIST_TAGS_FOR_RESOURCE
-                        || actionName == AccountConstants.Action.DESCRIBE_ACCOUNT
-                        || actionName == AccountConstants.Action.LIST_ACCOUNTS) {
+                if (handlerName == AccountConstants.Handler.READ
+                        || handlerName == AccountConstants.Handler.LIST) {
                     logger.log(String.format("Got %s when calling %s for "
                                     + "account [%s]. Retrying %s of %s ",
                             e.getClass().getName(), organizationsRequest.getClass().getName(), accountInfo, currentAttempt + 1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION));

--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/BaseHandlerStd.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/BaseHandlerStd.java
@@ -1,5 +1,7 @@
 package software.amazon.organizations.account;
 
+import software.amazon.awssdk.core.exception.RetryableException;
+import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import software.amazon.awssdk.services.organizations.model.AccessDeniedException;
 import software.amazon.awssdk.services.organizations.model.AccessDeniedForDependencyException;
@@ -183,25 +185,33 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         final AccountConstants.Action actionName,
         final AccountConstants.Handler handlerName
     ) {
-        try {
-            String accountInfo = model.getAccountId() == null ? handlerRequest.getLogicalResourceIdentifier() : model.getAccountId();
-            if (actionName != AccountConstants.Action.CREATE_ACCOUNT) {
-                int currentAttempt = context.getCurrentRetryAttempt(actionName, handlerName);
-                if (currentAttempt < MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION) {
-                    int callbackDelaySeconds = computeDelayBeforeNextRetry(currentAttempt, BASE_DELAY, RANDOMIZATION_FACTOR); // in seconds
-                    context.setCurrentRetryAttempt(actionName, handlerName);
+        String accountInfo = model.getAccountId() == null ? handlerRequest.getLogicalResourceIdentifier() : model.getAccountId();
+
+
+        if (actionName != AccountConstants.Action.CREATE_ACCOUNT) {
+            int currentAttempt = context.getCurrentRetryAttempt(actionName, handlerName);
+            if (currentAttempt < MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION) {
+                context.setCurrentRetryAttempt(actionName, handlerName);
+                if (actionName == AccountConstants.Action.LIST_PARENTS
+                        || actionName == AccountConstants.Action.LIST_TAGS_FOR_RESOURCE
+                        || actionName == AccountConstants.Action.DESCRIBE_ACCOUNT
+                        || actionName == AccountConstants.Action.LIST_ACCOUNTS) {
                     logger.log(String.format("Got %s when calling %s for "
-                                                 + "account [%s]. Retrying %s of %s with callback delay %s seconds.",
-                        e.getClass().getName(), organizationsRequest.getClass().getName(), accountInfo, currentAttempt + 1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION, callbackDelaySeconds));
-                    return ProgressEvent.defaultInProgressHandler(context, callbackDelaySeconds, model);
+                                    + "account [%s]. Retrying %s of %s ",
+                            e.getClass().getName(), organizationsRequest.getClass().getName(), accountInfo, currentAttempt + 1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION));
+                    throw RetryableException.builder().cause(e).build();
                 } else {
-                    logger.log(String.format("All retry attempts exhausted for account [%s], return exception to CloudFormation for further handling.", accountInfo));
-                    return handleError(organizationsRequest, handlerRequest, e, proxyClient, model, context, logger);
+                    int callbackDelaySeconds = computeDelayBeforeNextRetry(currentAttempt, BASE_DELAY, RANDOMIZATION_FACTOR); // in seconds
+                    logger.log(String.format("Got %s when calling %s for "
+                                    + "account [%s]. Retrying %s of %s with callback delay %s seconds.",
+                            e.getClass().getName(), organizationsRequest.getClass().getName(), accountInfo, currentAttempt + 1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION, callbackDelaySeconds));
+                    return ProgressEvent.defaultInProgressHandler(context, callbackDelaySeconds, model);
                 }
             }
-            return handleError(organizationsRequest, handlerRequest, e, proxyClient, model, context, logger);
-        } catch (Exception exception) {
-            return ProgressEvent.failed(model, context, HandlerErrorCode.GeneralServiceException, exception.getMessage());
         }
+        logger.log(String.format("All retry attempts exhausted for account [%s], return exception to CloudFormation for further handling.", accountInfo));
+        return handleError(organizationsRequest, handlerRequest, e, proxyClient, model, context, logger);
     }
+
+
 }

--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/BaseHandlerStd.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/BaseHandlerStd.java
@@ -147,9 +147,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             int currentAttempt = context.getCurrentRetryAttempt(actionName, handlerName);
             if (currentAttempt < MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION) {
                 context.setCurrentRetryAttempt(actionName, handlerName);
-                if (actionName == Constants.Action.DESCRIBE_OU
-                        || actionName == Constants.Action.LIST_PARENTS
-                        || actionName == Constants.Action.LIST_OU_FOR_PARENT) {
+                if (handlerName == Constants.Handler.READ
+                        || handlerName == Constants.Handler.LIST) {
                     logger.log(String.format("Got %s when calling %s for "
                                     + "organizational unit [%s]. Retrying %s of %s",
                             e.getClass().getName(), organizationsRequest.getClass().getName(), ouInfo, currentAttempt + 1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION));

--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/BaseHandlerStd.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/BaseHandlerStd.java
@@ -1,5 +1,6 @@
 package software.amazon.organizations.organizationalunit;
 
+import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.services.organizations.model.AccessDeniedException;
 import software.amazon.awssdk.services.organizations.model.AccessDeniedForDependencyException;
 import software.amazon.awssdk.services.organizations.model.AwsOrganizationsNotInUseException;
@@ -132,34 +133,39 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     }
 
     public final ProgressEvent<ResourceModel, CallbackContext> handleRetriableException(
-        final OrganizationsRequest organizationsRequest,
-        final ProxyClient<OrganizationsClient> proxyClient,
-        final CallbackContext context,
-        final Logger logger,
-        final Exception e,
-        final ResourceModel model,
-        final Constants.Action actionName,
-        final Constants.Handler handlerName
+            final OrganizationsRequest organizationsRequest,
+            final ProxyClient<OrganizationsClient> proxyClient,
+            final CallbackContext context,
+            final Logger logger,
+            final Exception e,
+            final ResourceModel model,
+            final Constants.Action actionName,
+            final Constants.Handler handlerName
     ) {
-        try {
-            String ouInfo = model.getId() == null ? model.getName() : model.getId();
-            if (actionName != Constants.Action.CREATE_OU) {
-                int currentAttempt = context.getCurrentRetryAttempt(actionName,handlerName);
-                if (currentAttempt < MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION) {
-                    int callbackDelaySeconds = computeDelayBeforeNextRetry(currentAttempt);
-                    context.setCurrentRetryAttempt(actionName,handlerName);
+        String ouInfo = model.getId() == null ? model.getName() : model.getId();
+        if (actionName != Constants.Action.CREATE_OU) {
+            int currentAttempt = context.getCurrentRetryAttempt(actionName, handlerName);
+            if (currentAttempt < MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION) {
+                context.setCurrentRetryAttempt(actionName, handlerName);
+                if (actionName == Constants.Action.DESCRIBE_OU
+                        || actionName == Constants.Action.LIST_PARENTS
+                        || actionName == Constants.Action.LIST_OU_FOR_PARENT) {
                     logger.log(String.format("Got %s when calling %s for "
-                                                 + "organizational unit [%s]. Retrying %s of %s with callback delay %s seconds.",
-                        e.getClass().getName(), organizationsRequest.getClass().getName(), ouInfo, currentAttempt+1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION, callbackDelaySeconds));
-                    return ProgressEvent.defaultInProgressHandler(context, callbackDelaySeconds, model);
+                                    + "organizational unit [%s]. Retrying %s of %s",
+                            e.getClass().getName(), organizationsRequest.getClass().getName(), ouInfo, currentAttempt + 1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION));
+                    throw RetryableException.builder().cause(e).build();
                 } else {
-                    logger.log(String.format("All retry exhausted. Return exception to CloudFormation for ou [%s].", ouInfo));
-                    return handleError(organizationsRequest, e, proxyClient, model, context, logger);
+
+                    int callbackDelaySeconds = computeDelayBeforeNextRetry(currentAttempt);
+                    logger.log(String.format("Got %s when calling %s for "
+                                    + "organizational unit [%s]. Retrying %s of %s with callback delay %s seconds.",
+                            e.getClass().getName(), organizationsRequest.getClass().getName(), ouInfo, currentAttempt + 1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION, callbackDelaySeconds));
+                    return ProgressEvent.defaultInProgressHandler(context, callbackDelaySeconds, model);
                 }
             }
-            return handleError(organizationsRequest, e, proxyClient, model, context, logger);
-        } catch (Exception exception){
-            return ProgressEvent.failed(model, context, HandlerErrorCode.GeneralServiceException, exception.getMessage());
         }
+        logger.log(String.format("All retry exhausted. Return exception to CloudFormation for ou [%s].", ouInfo));
+        return handleError(organizationsRequest, e, proxyClient, model, context, logger);
     }
+
 }

--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/ListHandler.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/ListHandler.java
@@ -11,8 +11,8 @@ import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ListHandler extends BaseHandlerStd {
     private Logger log;
@@ -38,23 +38,27 @@ public class ListHandler extends BaseHandlerStd {
         ListOrganizationalUnitsForParentRequest listOrganizationalUnitsForParentRequest =
             Translator.translateToListOrganizationalUnitsForParentRequest(request.getNextToken(), model);
 
-        ListOrganizationalUnitsForParentResponse listOrganizationalUnitsForParentResponse = null;
 
-        try {
-            listOrganizationalUnitsForParentResponse = awsClientProxy.injectCredentialsAndInvokeV2(
+        List<ResourceModel> models = new ArrayList<>();
+        return awsClientProxy.initiate("AWS-Organizations-OrganizationUnits::ListOrganizationUnits", orgsClient, model, callbackContext)
+                .translateToServiceRequest(t -> Translator.translateToListOrganizationalUnitsForParentRequest(request.getNextToken(), model))
+                .makeServiceCall(this::listOrganizationalUnits)
+                .handleError((organizationsRequest, e, proxyClient1, model1, context) ->
+                        handleErrorInGeneral(organizationsRequest, e, orgsClient, model, callbackContext, logger, Constants.Action.LIST_OU_FOR_PARENT, Constants.Handler.LIST))
+                .done(listOrganizationalUnitsForParentResponse -> {
+                    models.addAll(Translator.translateListAccountsResponseToResourceModel(listOrganizationalUnitsForParentResponse));
+                    return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                            .resourceModels(models)
+                            .nextToken(listOrganizationalUnitsForParentResponse.nextToken())
+                            .status(OperationStatus.SUCCESS)
+                            .build();
+                });
+
+    }
+
+    private ListOrganizationalUnitsForParentResponse listOrganizationalUnits(ListOrganizationalUnitsForParentRequest listOrganizationalUnitsForParentRequest, ProxyClient<OrganizationsClient> orgsClient) {
+        log.log("Start calling listOrganizationalUnits");
+        return orgsClient.injectCredentialsAndInvokeV2(
                 listOrganizationalUnitsForParentRequest, orgsClient.client()::listOrganizationalUnitsForParent);
-        } catch(Exception e) {
-            return handleErrorInGeneral(listOrganizationalUnitsForParentRequest, e, orgsClient, model, callbackContext, logger, Constants.Action.LIST_OU_FOR_PARENT, Constants.Handler.LIST);
-        }
-
-        final List<ResourceModel> models = listOrganizationalUnitsForParentResponse.organizationalUnits().stream().map(organizationalUnit ->
-                Translator.getResourceModelFromOrganizationalUnit(organizationalUnit)).collect(Collectors.toList());
-
-        return ProgressEvent.<ResourceModel, CallbackContext>builder()
-                .resourceModels(models)
-                .nextToken(listOrganizationalUnitsForParentResponse.nextToken())
-                .status(OperationStatus.SUCCESS)
-                .build();
-
     }
 }

--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/Translator.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/Translator.java
@@ -4,6 +4,7 @@ import software.amazon.awssdk.services.organizations.model.CreateOrganizationalU
 import software.amazon.awssdk.services.organizations.model.DeleteOrganizationalUnitRequest;
 import software.amazon.awssdk.services.organizations.model.DescribeOrganizationalUnitRequest;
 import software.amazon.awssdk.services.organizations.model.ListOrganizationalUnitsForParentRequest;
+import software.amazon.awssdk.services.organizations.model.ListOrganizationalUnitsForParentResponse;
 import software.amazon.awssdk.services.organizations.model.ListParentsRequest;
 import software.amazon.awssdk.services.organizations.model.ListTagsForResourceRequest;
 import software.amazon.awssdk.services.organizations.model.ListTagsForResourceResponse;
@@ -17,7 +18,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Translator {
 
@@ -133,5 +137,16 @@ public class Translator {
         }
 
         return tagsToReturn;
+    }
+
+    public static List<ResourceModel> translateListAccountsResponseToResourceModel(final ListOrganizationalUnitsForParentResponse listOrganizationalUnitsForParentResponse) {
+        return streamOfOrEmpty(listOrganizationalUnitsForParentResponse.organizationalUnits())
+                .map(organizationalUnit -> Translator.getResourceModelFromOrganizationalUnit(organizationalUnit)).collect(Collectors.toList());
+    }
+
+    private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {
+        return Optional.ofNullable(collection)
+                .map(Collection::stream)
+                .orElseGet(Stream::empty);
     }
 }

--- a/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/UpdateHandlerTest.java
+++ b/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/UpdateHandlerTest.java
@@ -84,14 +84,14 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ProgressEvent<ResourceModel, CallbackContext> response = updateHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
 
-        final Collection<Tag> tagsToAddOrUpdate = updateHandler.getTagsToAddOrUpdate(
-            TagTestResourcesHelper.translateOrganizationalUnitTagsToOrganizationTags(previousResourceModel.getTags()),
-            TagTestResourcesHelper.translateOrganizationalUnitTagsToOrganizationTags(model.getTags())
+        final Collection<Tag> tagsToAddOrUpdate = UpdateHandler.getTagsToAddOrUpdate(
+                TagTestResourcesHelper.translateOrganizationalUnitTagsToOrganizationTags(previousResourceModel.getTags()),
+                TagTestResourcesHelper.translateOrganizationalUnitTagsToOrganizationTags(model.getTags())
         );
 
-        final List<String> tagsToRemove = updateHandler.getTagsToRemove(
-            TagTestResourcesHelper.translateOrganizationalUnitTagsToOrganizationTags(previousResourceModel.getTags()),
-            TagTestResourcesHelper.translateOrganizationalUnitTagsToOrganizationTags(model.getTags())
+        final List<String> tagsToRemove = UpdateHandler.getTagsToRemove(
+                TagTestResourcesHelper.translateOrganizationalUnitTagsToOrganizationTags(previousResourceModel.getTags()),
+                TagTestResourcesHelper.translateOrganizationalUnitTagsToOrganizationTags(model.getTags())
         );
 
         assertThat(response).isNotNull();

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/BaseHandlerStd.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/BaseHandlerStd.java
@@ -2,7 +2,6 @@ package software.amazon.organizations.policy;
 
 import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
-
 import software.amazon.awssdk.services.organizations.model.AccessDeniedException;
 import software.amazon.awssdk.services.organizations.model.AwsOrganizationsNotInUseException;
 import software.amazon.awssdk.services.organizations.model.ConcurrentModificationException;
@@ -21,14 +20,13 @@ import software.amazon.awssdk.services.organizations.model.PolicyTypeNotEnabledE
 import software.amazon.awssdk.services.organizations.model.ServiceException;
 import software.amazon.awssdk.services.organizations.model.TargetNotFoundException;
 import software.amazon.awssdk.services.organizations.model.TooManyRequestsException;
-
 import software.amazon.awssdk.services.organizations.model.UnsupportedApiEndpointException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
+import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
-import software.amazon.cloudformation.proxy.HandlerErrorCode;
 
 import java.util.Random;
 
@@ -146,11 +144,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
             int currentAttempt = context.getCurrentRetryAttempt(actionName, handlerName);
             if (currentAttempt < MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION) {
                 context.setCurrentRetryAttempt(actionName, handlerName);
-                if (actionName == PolicyConstants.Action.DESCRIBE_POLICY
-                        || actionName == PolicyConstants.Action.LIST_POLICIES
-                        || actionName == PolicyConstants.Action.LIST_TAGS_FOR_POLICY
-                        || actionName == PolicyConstants.Action.LIST_TARGETS_FOR_POLICY) {
-
+                if (handlerName == PolicyConstants.Handler.READ
+                        || handlerName == PolicyConstants.Handler.LIST) {
                     logger.log(String.format("Got %s when calling %s for "
                                     + "policy [%s]. Retrying %s of %s ",
                             e.getClass().getName(), organizationsRequest.getClass().getName(), model.getName(), currentAttempt + 1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION));

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/BaseHandlerStd.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/BaseHandlerStd.java
@@ -1,5 +1,6 @@
 package software.amazon.organizations.policy;
 
+import software.amazon.awssdk.core.exception.RetryableException;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 
 import software.amazon.awssdk.services.organizations.model.AccessDeniedException;
@@ -132,33 +133,38 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     }
 
     public final ProgressEvent<ResourceModel, CallbackContext> handleRetriableException(
-        final OrganizationsRequest organizationsRequest,
-        final ProxyClient<OrganizationsClient> proxyClient,
-        final CallbackContext context,
-        final Logger logger,
-        final Exception e,
-        final ResourceModel model,
-        final PolicyConstants.Action actionName,
-        final PolicyConstants.Handler handlerName
+            final OrganizationsRequest organizationsRequest,
+            final ProxyClient<OrganizationsClient> proxyClient,
+            final CallbackContext context,
+            final Logger logger,
+            final Exception e,
+            final ResourceModel model,
+            final PolicyConstants.Action actionName,
+            final PolicyConstants.Handler handlerName
     ) {
-        try {
-            if (actionName != PolicyConstants.Action.CREATE_POLICY) {
-                int currentAttempt = context.getCurrentRetryAttempt(actionName, handlerName);
-                if (currentAttempt < MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION) {
-                    int callbackDelaySeconds = computeDelayBeforeNextRetry(currentAttempt);
-                    context.setCurrentRetryAttempt(actionName, handlerName);
+        if (actionName != PolicyConstants.Action.CREATE_POLICY) {
+            int currentAttempt = context.getCurrentRetryAttempt(actionName, handlerName);
+            if (currentAttempt < MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION) {
+                context.setCurrentRetryAttempt(actionName, handlerName);
+                if (actionName == PolicyConstants.Action.DESCRIBE_POLICY
+                        || actionName == PolicyConstants.Action.LIST_POLICIES
+                        || actionName == PolicyConstants.Action.LIST_TAGS_FOR_POLICY
+                        || actionName == PolicyConstants.Action.LIST_TARGETS_FOR_POLICY) {
+
                     logger.log(String.format("Got %s when calling %s for "
-                                                 + "policy [%s]. Retrying %s of %s with callback delay %s seconds.",
-                        e.getClass().getName(), organizationsRequest.getClass().getName(), model.getName(), currentAttempt+1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION, callbackDelaySeconds));
-                    return ProgressEvent.defaultInProgressHandler(context,callbackDelaySeconds, model);
+                                    + "policy [%s]. Retrying %s of %s ",
+                            e.getClass().getName(), organizationsRequest.getClass().getName(), model.getName(), currentAttempt + 1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION));
+                    throw RetryableException.builder().cause(e).build();
                 } else {
-                    logger.log(String.format("All retry attempts exhausted for policy [%s], return CloudFormation exception.", model.getName()));
-                    return handleError(organizationsRequest, e, proxyClient, model, context, logger);
+                    int callbackDelaySeconds = computeDelayBeforeNextRetry(currentAttempt);
+                    logger.log(String.format("Got %s when calling %s for "
+                                    + "policy [%s]. Retrying %s of %s with callback delay %s seconds.",
+                            e.getClass().getName(), organizationsRequest.getClass().getName(), model.getName(), currentAttempt + 1, MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION, callbackDelaySeconds));
+                    return ProgressEvent.defaultInProgressHandler(context, callbackDelaySeconds, model);
                 }
             }
-            return handleError(organizationsRequest, e, proxyClient, model, context, logger);
-        } catch (Exception exception){
-            return ProgressEvent.failed(model, context, HandlerErrorCode.GeneralServiceException, exception.getMessage());
         }
+        logger.log(String.format("All retry attempts exhausted for policy [%s], return CloudFormation exception.", model.getName()));
+        return handleError(organizationsRequest, e, proxyClient, model, context, logger);
     }
 }


### PR DESCRIPTION

Read and List handlers are not allowed to return IN_PROGRESS events. Updated the read/list handler error handling to return the correct status.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
