### PR TITLE
Support JSON in policy content

### DIFF
--- a/aws-organizations-policy/aws-organizations-policy.json
+++ b/aws-organizations-policy/aws-organizations-policy.json
@@ -21,8 +21,11 @@
       ]
     },
     "Content": {
-      "description": "The Policy text content",
-      "type": "string",
+      "description": "The Policy text content. For AWS CloudFormation templates formatted in YAML, you can provide the policy in JSON or YAML format. AWS CloudFormation always converts a YAML policy to JSON format before submitting it.",
+      "type": [
+        "object",
+        "string"
+      ],
       "pattern": "[\\s\\S]*",
       "minLength": 1,
       "maxLength": 1000000

--- a/aws-organizations-policy/docs/README.md
+++ b/aws-organizations-policy/docs/README.md
@@ -14,7 +14,7 @@ To declare this entity in your AWS CloudFormation template, use the following sy
     "Properties" : {
         "<a href="#name" title="Name">Name</a>" : <i>String</i>,
         "<a href="#type" title="Type">Type</a>" : <i>String</i>,
-        "<a href="#content" title="Content">Content</a>" : <i>String</i>,
+        "<a href="#content" title="Content">Content</a>" : <i>Map, String</i>,
         "<a href="#description" title="Description">Description</a>" : <i>String</i>,
         "<a href="#targetids" title="TargetIds">TargetIds</a>" : <i>[ String, ... ]</i>,
         "<a href="#tags" title="Tags">Tags</a>" : <i>[ <a href="tag.md">Tag</a>, ... ]</i>,
@@ -29,7 +29,7 @@ Type: AWS::Organizations::Policy
 Properties:
     <a href="#name" title="Name">Name</a>: <i>String</i>
     <a href="#type" title="Type">Type</a>: <i>String</i>
-    <a href="#content" title="Content">Content</a>: <i>String</i>
+    <a href="#content" title="Content">Content</a>: <i>Map, String</i>
     <a href="#description" title="Description">Description</a>: <i>String</i>
     <a href="#targetids" title="TargetIds">TargetIds</a>: <i>
       - String</i>
@@ -69,11 +69,11 @@ _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/l
 
 #### Content
 
-The Policy text content
+The Policy text content. For AWS CloudFormation templates formatted in YAML, you can provide the policy in JSON or YAML format. AWS CloudFormation always converts a YAML policy to JSON format before submitting it.
 
 _Required_: Yes
 
-_Type_: String
+_Type_: Map, String
 
 _Minimum_: <code>1</code>
 

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/CreateHandler.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/CreateHandler.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.services.organizations.model.AttachPolicyResponse;
 import software.amazon.awssdk.services.organizations.model.CreatePolicyRequest;
 import software.amazon.awssdk.services.organizations.model.CreatePolicyResponse;
 import software.amazon.awssdk.services.organizations.model.DuplicatePolicyAttachmentException;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
 import software.amazon.cloudformation.proxy.Logger;
@@ -31,6 +32,15 @@ public class CreateHandler extends BaseHandlerStd {
         if (model.getName() == null || model.getType() == null || model.getContent() == null) {
             return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InvalidRequest,
                 "Policy cannot be created without name, type, and content!");
+        }
+
+        String content;
+        try {
+            content = Translator.convertObjectToString(model.getContent());
+        } catch (CfnInvalidRequestException e){
+            logger.log(String.format("The policy content did not include a valid JSON. This is an InvalidRequest for management account Id [%s]", request.getAwsAccountId()));
+            return ProgressEvent.failed(model, callbackContext, HandlerErrorCode.InvalidRequest,
+                "Policy content had invalid JSON!");
         }
 
         logger.log(String.format("Entered %s create handler with account Id [%s], with Content [%s], Description [%s], Name [%s], Type [%s]",

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/Translator.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/Translator.java
@@ -13,6 +13,8 @@ import software.amazon.awssdk.services.organizations.model.Tag;
 import software.amazon.awssdk.services.organizations.model.TagResourceRequest;
 import software.amazon.awssdk.services.organizations.model.UntagResourceRequest;
 import software.amazon.awssdk.services.organizations.model.UpdatePolicyRequest;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,10 +32,13 @@ import java.util.stream.Stream;
  * - resource model construction for read/list handlers
  */
 public class Translator {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     static CreatePolicyRequest translateToCreateRequest(final ResourceModel model) {
+        String content = convertObjectToString(model.getContent());
         if (model.getTags() == null) {
             return CreatePolicyRequest.builder()
-                .content(model.getContent())
+                .content(content)
                 .description(getOptionalDescription(model))
                 .name(model.getName())
                 .type(model.getType())
@@ -45,7 +50,7 @@ public class Translator {
             tags.add(Tag.builder().key(tag.getKey()).value(tag.getValue()).build());
         });
         return CreatePolicyRequest.builder()
-            .content(model.getContent())
+            .content(content)
             .description(getOptionalDescription(model))
             .name(model.getName())
             .type(model.getType())
@@ -75,7 +80,7 @@ public class Translator {
             .policyId(model.getId())
             .name(model.getName())
             .description(getOptionalDescription(model))
-            .content(model.getContent())
+            .content(convertObjectToString(model.getContent()))
             .build();
     }
 
@@ -134,6 +139,22 @@ public class Translator {
                 .description(policy.description())
                 .build())
             .collect(Collectors.toList());
+    }
+
+    /**
+     * Converts user inputted JSON to a String
+     * @param content
+     * @return
+     **/
+    static String convertObjectToString(Object content) {
+        try {
+            if (content instanceof String) {
+                return (String)content;
+            }
+            return MAPPER.writeValueAsString(content);
+        } catch (Exception e) {
+            throw new CfnInvalidRequestException(e);
+        }
     }
 
     private static <T> Stream<T> streamOfOrEmpty(final Collection<T> collection) {

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/Translator.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/Translator.java
@@ -13,6 +13,7 @@ import software.amazon.awssdk.services.organizations.model.Tag;
 import software.amazon.awssdk.services.organizations.model.TagResourceRequest;
 import software.amazon.awssdk.services.organizations.model.UntagResourceRequest;
 import software.amazon.awssdk.services.organizations.model.UpdatePolicyRequest;
+import software.amazon.cloudformation.exceptions.CfnHandlerInternalFailureException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -20,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -154,6 +156,19 @@ public class Translator {
             return MAPPER.writeValueAsString(content);
         } catch (Exception e) {
             throw new CfnInvalidRequestException(e);
+        }
+    }
+
+    /**
+     * Converts String to JSON object
+     * @param content
+     * @return
+     **/
+    static Object convertStringToObject(String content) {
+        try {
+            return MAPPER.readValue(content, Map.class);
+        } catch (Exception e) {
+            throw new CfnHandlerInternalFailureException(e);
         }
     }
 

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
@@ -1,9 +1,12 @@
 package software.amazon.organizations.policy;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableSet;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -17,12 +20,14 @@ import software.amazon.awssdk.services.organizations.model.DescribePolicyRespons
 import software.amazon.awssdk.services.organizations.model.Policy;
 import software.amazon.awssdk.services.organizations.model.PolicySummary;
 import software.amazon.awssdk.services.organizations.model.PolicyTargetSummary;
+import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.Credentials;
 import software.amazon.cloudformation.proxy.LoggerProxy;
 import software.amazon.cloudformation.proxy.ProxyClient;
 
 public class AbstractTestBase {
+    private static final ObjectMapper MAPPER = new ObjectMapper();
     protected static final String TEST_POLICY_ID = "p-1231231231";
     protected static final String TEST_POLICY_ID_CHANGED = "p-3213213213";
     protected static final String TEST_POLICY_ARN = "arn:aws:organizations:555555555555:policy/p-1231231231";
@@ -30,6 +35,8 @@ public class AbstractTestBase {
     protected static final String TEST_POLICY_NAME = "AllowAllS3Actions";
     protected static final String TEST_POLICY_DESCRIPTION = "Allow All S3 Actions";
     protected static final String TEST_POLICY_UPDATED_CONTENT = "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Deny\\\",\\\"Action\\\":[\\\"s3:*\\\"],\\\"Resource\\\":[\\\"*\\\"]}]}";
+    protected static final String TEST_POLICY_CONTENT_FOR_JSON = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:*\"],\"Resource\":[\"*\"]}]}";
+    protected static final String TEST_POLICY_UPDATED_CONTENT_FOR_JSON = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Deny\",\"Action\":[\"s3:*\"],\"Resource\":[\"*\"]}]}";
     protected static final String TEST_POLICY_UPDATED_NAME = "DenyAllS3Actions";
     protected static final String TEST_POLICY_UPDATED_DESCRIPTION = "Deny All S3 Actions";
     protected static final String TEST_TYPE = PolicyConstants.PolicyType.SERVICE_CONTROL_POLICY.toString();
@@ -41,7 +48,7 @@ public class AbstractTestBase {
     protected static final Set<String> TEST_TARGET_IDS = ImmutableSet.of(TEST_TARGET_ROOT_ID, TEST_TARGET_OU_ID);
     protected static final Set<String> TEST_UPDATED_TARGET_IDS = ImmutableSet.of(TEST_TARGET_ROOT_ID, TEST_TARGET_ACCOUNT_ID);
     protected static final String TEST_NEXT_TOKEN = "mockNextTokenItem";
-    protected static final String POLICY_SCHEMA_SHA256_HEXSTRING = "B22C4432E6B98EF865EFB5335B8E7905B3F94FB9AAAC9B1B2463B98A138AF4CC";
+    protected static final String POLICY_SCHEMA_SHA256_HEXSTRING = "A562D1A859C2312EDE249C91077773796CD3DB7FFD41624D8B3D0D3C7481D6AA";
     protected static final String POLICY_JSON_SCHEMA_FILE_NAME = "aws-organizations-policy.json";
 
     protected static final Credentials MOCK_CREDENTIALS;
@@ -108,6 +115,19 @@ public class AbstractTestBase {
             .build();
     }
 
+    static ResourceModel generateInitialResourceModelWithJsonContent(boolean hasTargets, boolean hasTags) {
+        return ResourceModel.builder()
+                   .targetIds(hasTargets ? TEST_TARGET_IDS : new HashSet<>())
+                   .tags(hasTags
+                             ? TagTestResourceHelper.translateOrganizationTagsToPolicyTags(TagTestResourceHelper.defaultTags)
+                             : null)
+                   .description(TEST_POLICY_DESCRIPTION)
+                   .content(convertStringToJsonObject(TEST_POLICY_CONTENT_FOR_JSON))
+                   .name(TEST_POLICY_NAME)
+                   .type(TEST_TYPE)
+                   .build();
+    }
+
     static ResourceModel generateFinalResourceModel(boolean hasTargets, boolean hasTags) {
         return ResourceModel.builder()
             .targetIds(hasTargets ? TEST_TARGET_IDS : new HashSet<>())
@@ -140,6 +160,22 @@ public class AbstractTestBase {
             .build();
     }
 
+    static ResourceModel generateUpdatedResourceModelWithJsonContent(boolean hasTargets, boolean hasTags) {
+        return ResourceModel.builder()
+                   .id(TEST_POLICY_ID)
+                   .arn(TEST_POLICY_ARN)
+                   .awsManaged(TEST_AWSMANAGED)
+                   .name(TEST_POLICY_UPDATED_NAME)
+                   .type(TEST_TYPE)
+                   .content(convertStringToJsonObject(TEST_POLICY_UPDATED_CONTENT_FOR_JSON))
+                   .description(TEST_POLICY_UPDATED_DESCRIPTION)
+                   .targetIds(hasTargets ? TEST_UPDATED_TARGET_IDS : new HashSet<>())
+                   .tags(hasTags
+                             ? TagTestResourceHelper.translateOrganizationTagsToPolicyTags(TagTestResourceHelper.updatedTags)
+                             : null)
+                   .build();
+    }
+
     static DescribePolicyResponse getDescribePolicyResponse() {
         return DescribePolicyResponse.builder().policy(
                 Policy.builder()
@@ -160,5 +196,21 @@ public class AbstractTestBase {
         return PolicyTargetSummary.builder()
             .targetId(targetId)
             .build();
+    }
+
+    /**
+     * Converts a String to a JSON object.
+     * Ref: https://fasterxml.github.io/jackson-databind/javadoc/2.7/com/fasterxml/jackson/databind/ObjectMapper.html#readValue(java.lang.String,%20com.fasterxml.jackson.core.type.TypeReference)
+     *
+     * @param content
+     * @return Map<String, Object>
+     */
+    static Map<String, Object> convertStringToJsonObject(final String content) {
+        try {
+            return MAPPER.readValue(content, new TypeReference<Map<String, Object>>() {
+            });
+        } catch (Exception e) {
+            throw new CfnInvalidRequestException(e);
+        }
     }
 }

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
@@ -31,12 +31,12 @@ public class AbstractTestBase {
     protected static final String TEST_POLICY_ID = "p-1231231231";
     protected static final String TEST_POLICY_ID_CHANGED = "p-3213213213";
     protected static final String TEST_POLICY_ARN = "arn:aws:organizations:555555555555:policy/p-1231231231";
-    protected static final String TEST_POLICY_CONTENT = "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Allow\\\",\\\"Action\\\":[\\\"s3:*\\\"],\\\"Resource\\\":[\\\"*\\\"]}]}";
+    protected static final String TEST_POLICY_CONTENT = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:*\"],\"Resource\":[\"*\"]}]}";
+    protected static final Map<String, Object> TEST_POLICY_CONTENT_JSON = convertStringToJsonObject(TEST_POLICY_CONTENT);
+    protected static final String TEST_POLICY_UPDATED_CONTENT = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Deny\",\"Action\":[\"s3:*\"],\"Resource\":[\"*\"]}]}";
+    protected static final Map<String, Object> TEST_POLICY_UPDATED_CONTENT_JSON = convertStringToJsonObject(TEST_POLICY_UPDATED_CONTENT);
     protected static final String TEST_POLICY_NAME = "AllowAllS3Actions";
     protected static final String TEST_POLICY_DESCRIPTION = "Allow All S3 Actions";
-    protected static final String TEST_POLICY_UPDATED_CONTENT = "{\\\"Version\\\":\\\"2012-10-17\\\",\\\"Statement\\\":[{\\\"Effect\\\":\\\"Deny\\\",\\\"Action\\\":[\\\"s3:*\\\"],\\\"Resource\\\":[\\\"*\\\"]}]}";
-    protected static final String TEST_POLICY_CONTENT_FOR_JSON = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Action\":[\"s3:*\"],\"Resource\":[\"*\"]}]}";
-    protected static final String TEST_POLICY_UPDATED_CONTENT_FOR_JSON = "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Deny\",\"Action\":[\"s3:*\"],\"Resource\":[\"*\"]}]}";
     protected static final String TEST_POLICY_UPDATED_NAME = "DenyAllS3Actions";
     protected static final String TEST_POLICY_UPDATED_DESCRIPTION = "Deny All S3 Actions";
     protected static final String TEST_TYPE = PolicyConstants.PolicyType.SERVICE_CONTROL_POLICY.toString();
@@ -102,6 +102,7 @@ public class AbstractTestBase {
         };
     }
 
+    // recommended content type is JSON
     static ResourceModel generateInitialResourceModel(boolean hasTargets, boolean hasTags) {
         return ResourceModel.builder()
             .targetIds(hasTargets ? TEST_TARGET_IDS : new HashSet<>())
@@ -115,14 +116,14 @@ public class AbstractTestBase {
             .build();
     }
 
-    static ResourceModel generateInitialResourceModelWithJsonContent(boolean hasTargets, boolean hasTags) {
+    static ResourceModel generateInitialResourceModelWithJsonStringContent(boolean hasTargets, boolean hasTags) {
         return ResourceModel.builder()
                    .targetIds(hasTargets ? TEST_TARGET_IDS : new HashSet<>())
                    .tags(hasTags
                              ? TagTestResourceHelper.translateOrganizationTagsToPolicyTags(TagTestResourceHelper.defaultTags)
                              : null)
                    .description(TEST_POLICY_DESCRIPTION)
-                   .content(convertStringToJsonObject(TEST_POLICY_CONTENT_FOR_JSON))
+                   .content(TEST_POLICY_CONTENT)
                    .name(TEST_POLICY_NAME)
                    .type(TEST_TYPE)
                    .build();
@@ -133,7 +134,7 @@ public class AbstractTestBase {
             .targetIds(hasTargets ? TEST_TARGET_IDS : new HashSet<>())
             .arn(TEST_POLICY_ARN)
             .description(TEST_POLICY_DESCRIPTION)
-            .content(TEST_POLICY_CONTENT)
+            .content(TEST_POLICY_CONTENT_JSON)
             .id(TEST_POLICY_ID)
             .name(TEST_POLICY_NAME)
             .type(TEST_TYPE)
@@ -151,7 +152,7 @@ public class AbstractTestBase {
             .awsManaged(TEST_AWSMANAGED)
             .name(TEST_POLICY_UPDATED_NAME)
             .type(TEST_TYPE)
-            .content(TEST_POLICY_UPDATED_CONTENT)
+            .content(TEST_POLICY_UPDATED_CONTENT_JSON)
             .description(TEST_POLICY_UPDATED_DESCRIPTION)
             .targetIds(hasTargets ? TEST_UPDATED_TARGET_IDS : new HashSet<>())
             .tags(hasTags
@@ -167,7 +168,7 @@ public class AbstractTestBase {
                    .awsManaged(TEST_AWSMANAGED)
                    .name(TEST_POLICY_UPDATED_NAME)
                    .type(TEST_TYPE)
-                   .content(convertStringToJsonObject(TEST_POLICY_UPDATED_CONTENT_FOR_JSON))
+                   .content(TEST_POLICY_UPDATED_CONTENT_JSON)
                    .description(TEST_POLICY_UPDATED_DESCRIPTION)
                    .targetIds(hasTargets ? TEST_UPDATED_TARGET_IDS : new HashSet<>())
                    .tags(hasTags

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
@@ -120,6 +120,60 @@ public class CreateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void handleRequest_NoTargetsNoTags_WithJSONContent_SimpleSuccess() {
+        final ResourceModel model = generateInitialResourceModelWithJsonContent(false, false);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                                                                  .desiredResourceState(model)
+                                                                  .build();
+
+        final CreatePolicyResponse createPolicyResponse = getCreatePolicyResponse();
+        when(mockProxyClient.client().createPolicy(any(CreatePolicyRequest.class))).thenReturn(createPolicyResponse);
+
+        final DescribePolicyResponse describePolicyResponse = getDescribePolicyResponse();
+        when(mockProxyClient.client().describePolicy(any(DescribePolicyRequest.class))).thenReturn(describePolicyResponse);
+
+        final ListTargetsForPolicyResponse listTargetsResponse = ListTargetsForPolicyResponse.builder()
+                                                                     .nextToken(null)
+                                                                     .build();
+        when(mockProxyClient.client().listTargetsForPolicy(any(ListTargetsForPolicyRequest.class))).thenReturn(listTargetsResponse);
+
+        final ListTagsForResourceResponse listTagsResponse = TagTestResourceHelper.buildEmptyTagsResponse();
+        when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsResponse);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+
+        final ResourceModel finalModel = ResourceModel.builder()
+                                             .targetIds(new HashSet<>())
+                                             .arn(TEST_POLICY_ARN)
+                                             .description(TEST_POLICY_DESCRIPTION)
+                                             .content(TEST_POLICY_CONTENT)
+                                             .id(TEST_POLICY_ID)
+                                             .name(TEST_POLICY_NAME)
+                                             .type(TEST_TYPE)
+                                             .awsManaged(TEST_AWSMANAGED)
+                                             .tags(TagTestResourceHelper.translateOrganizationTagsToPolicyTags(null))
+                                             .build();
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNotNull();
+        assertThat(response.getResourceModel()).isEqualTo(finalModel);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(mockProxyClient.client()).createPolicy(any(CreatePolicyRequest.class));
+        verify(mockProxyClient.client()).describePolicy(any(DescribePolicyRequest.class));
+        verify(mockProxyClient.client()).listTargetsForPolicy(any(ListTargetsForPolicyRequest.class));
+        verify(mockProxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
+
+        verify(mockOrgsClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(mockOrgsClient);
+    }
+
+    @Test
     public void handleRequest_NoDescriptionNoTargetsNoTags_SimpleRequest() {
         final ResourceModel model = ResourceModel.builder()
             .targetIds(new HashSet<>())

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
@@ -38,7 +38,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.atMost;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
@@ -93,14 +92,13 @@ public class CreateHandlerTest extends AbstractTestBase {
             .targetIds(new HashSet<>())
             .arn(TEST_POLICY_ARN)
             .description(TEST_POLICY_DESCRIPTION)
-            .content(TEST_POLICY_CONTENT)
+            .content(TEST_POLICY_CONTENT_JSON)
             .id(TEST_POLICY_ID)
             .name(TEST_POLICY_NAME)
             .type(TEST_TYPE)
             .awsManaged(TEST_AWSMANAGED)
             .tags(TagTestResourceHelper.translateOrganizationTagsToPolicyTags(null))
             .build();
-
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
@@ -120,8 +118,8 @@ public class CreateHandlerTest extends AbstractTestBase {
     }
 
     @Test
-    public void handleRequest_NoTargetsNoTags_WithJSONContent_SimpleSuccess() {
-        final ResourceModel model = generateInitialResourceModelWithJsonContent(false, false);
+    public void handleRequest_NoTargetsNoTags_WithJSONStringContent_SimpleSuccess() {
+        final ResourceModel model = generateInitialResourceModelWithJsonStringContent(false, false);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
@@ -147,14 +145,13 @@ public class CreateHandlerTest extends AbstractTestBase {
                                              .targetIds(new HashSet<>())
                                              .arn(TEST_POLICY_ARN)
                                              .description(TEST_POLICY_DESCRIPTION)
-                                             .content(TEST_POLICY_CONTENT)
+                                             .content(TEST_POLICY_CONTENT_JSON)
                                              .id(TEST_POLICY_ID)
                                              .name(TEST_POLICY_NAME)
                                              .type(TEST_TYPE)
                                              .awsManaged(TEST_AWSMANAGED)
                                              .tags(TagTestResourceHelper.translateOrganizationTagsToPolicyTags(null))
                                              .build();
-
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
@@ -208,14 +205,13 @@ public class CreateHandlerTest extends AbstractTestBase {
             .targetIds(new HashSet<>())
             .arn(TEST_POLICY_ARN)
             .description(TEST_POLICY_DESCRIPTION)
-            .content(TEST_POLICY_CONTENT)
+            .content(TEST_POLICY_CONTENT_JSON)
             .id(TEST_POLICY_ID)
             .name(TEST_POLICY_NAME)
             .type(TEST_TYPE)
             .awsManaged(TEST_AWSMANAGED)
             .tags(TagTestResourceHelper.translateOrganizationTagsToPolicyTags(null))
             .build();
-
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/UpdateHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/UpdateHandlerTest.java
@@ -118,6 +118,52 @@ public class UpdateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void handleRequest_WithJsonContent_SimpleSuccess() {
+        final ResourceModel initialResourceModel = generateFinalResourceModel(false, false);
+        final ResourceModel updatedResourceModel = generateUpdatedResourceModelWithJsonContent(false, false);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                                                                  .previousResourceState(initialResourceModel)
+                                                                  .desiredResourceState(updatedResourceModel)
+                                                                  .build();
+
+        final UpdatePolicyResponse updatePolicyResponse = getUpdatePolicyResponse();
+        when(mockProxyClient.client().updatePolicy(any(UpdatePolicyRequest.class))).thenReturn(updatePolicyResponse);
+
+        final DescribePolicyResponse describePolicyResponse = getDescribePolicyResponse();
+        when(mockProxyClient.client().describePolicy(any(DescribePolicyRequest.class))).thenReturn(describePolicyResponse);
+
+        final ListTargetsForPolicyResponse listTargetsResponse = ListTargetsForPolicyResponse.builder()
+                                                                     .targets(new ArrayList<>())
+                                                                     .nextToken(null)
+                                                                     .build();
+
+        when(mockProxyClient.client().listTargetsForPolicy(any(ListTargetsForPolicyRequest.class))).thenReturn(listTargetsResponse);
+
+        final ListTagsForResourceResponse listTagsResponse = TagTestResourceHelper.buildEmptyTagsResponse();
+        when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsResponse);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = updateHandlerToTest.handleRequest(mockAwsClientproxy, request, new CallbackContext(), mockProxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackContext()).isNull();
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        verify(mockProxyClient.client()).updatePolicy(any(UpdatePolicyRequest.class));
+        verify(mockProxyClient.client()).describePolicy(any(DescribePolicyRequest.class));
+        verify(mockProxyClient.client()).listTargetsForPolicy(any(ListTargetsForPolicyRequest.class));
+        verify(mockProxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
+
+        verify(mockOrgsClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(mockOrgsClient);
+    }
+
+    @Test
     public void handleRequest_WithTargets_SimpleSuccess() {
         final ResourceModel initialResourceModel = generateFinalResourceModel(true, false);
         final ResourceModel updatedResourceModel = generateUpdatedResourceModel(true, false);

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ phases:
       -  pip install --upgrade 'botocore==1.27.4'
       -  pip install --upgrade 'pyyaml==5.4.1'
       -  pip install --upgrade 'requests==2.27.1'
+      -  pip install --upgrade 'aws-sam-translator==1.22.0'
       -  pip install pre-commit cloudformation-cli-java-plugin
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,6 +11,7 @@ phases:
       -  pip install --upgrade 'botocore==1.27.4'
       -  pip install --upgrade 'pyyaml==5.4.1'
       -  pip install --upgrade 'requests==2.27.1'
+      -  pip install --upgrade 'aws-sam-cli==1.73.0'
       -  pip install pre-commit cloudformation-cli-java-plugin
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,8 +10,8 @@ phases:
       -  pip install --upgrade 'urllib3==1.26.9'
       -  pip install --upgrade 'botocore==1.27.4'
       -  pip install --upgrade 'pyyaml==5.4.1'
-      -  pip install --upgrade 'requests==2.27.1'
       -  pip install --upgrade 'aws-sam-cli==1.73.0'
+      -  pip install --upgrade 'requests==2.27.1'
       -  pip install pre-commit cloudformation-cli-java-plugin
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,7 +11,6 @@ phases:
       -  pip install --upgrade 'botocore==1.27.4'
       -  pip install --upgrade 'pyyaml==5.4.1'
       -  pip install --upgrade 'requests==2.27.1'
-      -  pip install --upgrade 'aws-sam-translator==1.22.0'
       -  pip install pre-commit cloudformation-cli-java-plugin
   build:
     commands:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- support both JSON and JSONString in policy content
- return content in JSON format in READ handler for drift detection
- make changes to corresponding unit tests, default for content is now JSON 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
