### PR TITLE
Add SourceParentNotFoundException translation for Account UpdateHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@ This repository contains AWS-owned resource providers for the `AWS::Organization
 - [AWS::Organizations::Account](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-organizations-account.html)
 - [AWS::Organizations::OrganizationalUnit](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-organizations-organizationalunit.html)
 - [AWS::Organizations::Policy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-organizations-policy.html)
+- [AWS::Organizations::ResourcePolicy](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-organizations-resourcepolicy.html)
 
 ## Usage
 
-Instructions on repositry setup and local development can be found in the [Contributing Guidelines](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-organizations/blob/main/CONTRIBUTING.md).
+Instructions on repository setup and local development can be found in the [Contributing Guidelines](https://github.com/aws-cloudformation/aws-cloudformation-resource-providers-organizations/blob/main/CONTRIBUTING.md).
 
 ## More Resources
 

--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/UpdateHandler.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/UpdateHandler.java
@@ -100,11 +100,12 @@ public class UpdateHandler extends BaseHandlerStd {
                                 .makeServiceCall(this::moveAccount)
                                 .handleError((organizationsRequest, e, proxyClient1, model1, context) -> {
                                     if (e instanceof DuplicateAccountException) {
-                                        log.log(String.format("Got %s when calling %s for "
+                                        logger.log(String.format("Got %s when calling %s for "
                                                         + "account id [%s], source id [%s], destination id [%s]. Continue with next step.",
                                                 e.getClass().getName(), organizationsRequest.getClass().getName(), model.getAccountId(), sourceId, destinationId));
                                         return ProgressEvent.progress(model1, context);
                                     } else if (e instanceof SourceParentNotFoundException) {
+                                        logger.log("Thrown SourceParentNotFoundException when calling MoveAccount - translating to InvalidInputException.");
                                         InvalidInputException translatedException = InvalidInputException.builder()
                                             .message(e.getMessage())
                                             .build();

--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/UpdateHandler.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/UpdateHandler.java
@@ -4,10 +4,12 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import software.amazon.awssdk.services.organizations.model.DuplicateAccountException;
+import software.amazon.awssdk.services.organizations.model.InvalidInputException;
 import software.amazon.awssdk.services.organizations.model.ListRootsRequest;
 import software.amazon.awssdk.services.organizations.model.ListRootsResponse;
 import software.amazon.awssdk.services.organizations.model.MoveAccountRequest;
 import software.amazon.awssdk.services.organizations.model.MoveAccountResponse;
+import software.amazon.awssdk.services.organizations.model.SourceParentNotFoundException;
 import software.amazon.awssdk.services.organizations.model.Tag;
 import software.amazon.awssdk.services.organizations.model.TagResourceRequest;
 import software.amazon.awssdk.services.organizations.model.UntagResourceRequest;
@@ -102,8 +104,14 @@ public class UpdateHandler extends BaseHandlerStd {
                                                         + "account id [%s], source id [%s], destination id [%s]. Continue with next step.",
                                                 e.getClass().getName(), organizationsRequest.getClass().getName(), model.getAccountId(), sourceId, destinationId));
                                         return ProgressEvent.progress(model1, context);
+                                    } else if (e instanceof SourceParentNotFoundException) {
+                                        InvalidInputException translatedException = InvalidInputException.builder()
+                                            .message(e.getMessage())
+                                            .build();
+                                        return handleErrorInGeneral(organizationsRequest, request, translatedException, proxyClient1, model1, context, logger, AccountConstants.Action.MOVE_ACCOUNT, AccountConstants.Handler.UPDATE);
+                                    } else {
+                                        return handleErrorInGeneral(organizationsRequest, request, e, proxyClient1, model1, context, logger, AccountConstants.Action.MOVE_ACCOUNT, AccountConstants.Handler.UPDATE);
                                     }
-                                    return handleErrorInGeneral(organizationsRequest, request, e, proxyClient1, model1, context, logger, AccountConstants.Action.MOVE_ACCOUNT, AccountConstants.Handler.UPDATE);
                                 })
                                 .progress()
                 );

--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/UpdateHandler.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/UpdateHandler.java
@@ -105,7 +105,9 @@ public class UpdateHandler extends BaseHandlerStd {
                                                 e.getClass().getName(), organizationsRequest.getClass().getName(), model.getAccountId(), sourceId, destinationId));
                                         return ProgressEvent.progress(model1, context);
                                     } else if (e instanceof SourceParentNotFoundException) {
-                                        logger.log("Thrown SourceParentNotFoundException when calling MoveAccount - translating to InvalidInputException.");
+                                        logger.log(String.format("Got %s when calling %s for "
+                                                        + "account id [%s], source id [%s], destination id [%s]. Translating to InvalidInputException.",
+                                                e.getClass().getName(), organizationsRequest.getClass().getName(), model.getAccountId(), sourceId, destinationId));
                                         InvalidInputException translatedException = InvalidInputException.builder()
                                             .message(e.getMessage())
                                             .build();


### PR DESCRIPTION
***Issue #, if available:*** 
N/A

***Description of changes:*** 
This change translate the SourceParentNotFoundException to an InvalidInputException for the UpdateHandler - it adds a unit test to test this translation. A minor addition to the README is made to include ResourcePolicy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
