### PR TITLE
Adding Propagation Delay to the Organization Create Handler

### DIFF
--- a/aws-organizations-organization/src/main/java/software/amazon/organizations/organization/BaseHandlerStd.java
+++ b/aws-organizations-organization/src/main/java/software/amazon/organizations/organization/BaseHandlerStd.java
@@ -30,6 +30,8 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private static final int BASE_DELAY = 15; //in seconds
     private static final int MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION = 2;
 
+    protected static final int EVENTUAL_CONSISTENCY_DELAY_SECONDS = 1; //in seconds
+
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
             final AmazonWebServicesClientProxy proxy,

--- a/aws-organizations-organization/src/main/java/software/amazon/organizations/organization/CallbackContext.java
+++ b/aws-organizations-organization/src/main/java/software/amazon/organizations/organization/CallbackContext.java
@@ -12,6 +12,11 @@ import java.util.Map;
 public class CallbackContext extends StdCallbackContext {
     private Map<String, Integer> actionToRetryAttemptMap = new HashMap<>();
 
+    // Used to set Propagation Delay in the CreateHandler call chain.
+    public boolean propagationDelay = false;
+    // used in CREATE handler re-invoking
+    private boolean isOrgCreated = false;
+
     public int getCurrentRetryAttempt(final OrganizationConstants.Action actionName, final OrganizationConstants.Handler handlerName) {
         String key = actionName.toString() + handlerName.toString();
         return this.actionToRetryAttemptMap.getOrDefault(key, 0);

--- a/aws-organizations-organization/src/test/java/software/amazon/organizations/organization/CreateHandlerTest.java
+++ b/aws-organizations-organization/src/test/java/software/amazon/organizations/organization/CreateHandlerTest.java
@@ -94,7 +94,10 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .build();
         when(mockProxyClient.client().describeOrganization(any(DescribeOrganizationRequest.class))).thenReturn(describeOrganizationResponse);
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+        CallbackContext context = new CallbackContext();
+        context.setPropagationDelay(true);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, context, mockProxyClient, logger);
 
         final ResourceModel resultModel = generateResourceModel();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change includes adding 1s of propagation delay between the Create and Read calls of the Organization resource type to prevent eventual consistency issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
