### PR TITLE
add support for new policy type CHATBOT_POLICY

### DIFF
--- a/aws-organizations-policy/aws-organizations-policy.json
+++ b/aws-organizations-policy/aws-organizations-policy.json
@@ -11,13 +11,14 @@
       "maxLength": 128
     },
     "Type": {
-      "description": "The type of policy to create. You can specify one of the following values: AISERVICES_OPT_OUT_POLICY, BACKUP_POLICY, SERVICE_CONTROL_POLICY, TAG_POLICY",
+      "description": "The type of policy to create. You can specify one of the following values: AISERVICES_OPT_OUT_POLICY, BACKUP_POLICY, SERVICE_CONTROL_POLICY, TAG_POLICY, CHATBOT_POLICY",
       "type": "string",
       "enum": [
         "SERVICE_CONTROL_POLICY",
         "AISERVICES_OPT_OUT_POLICY",
         "BACKUP_POLICY",
-        "TAG_POLICY"
+        "TAG_POLICY",
+        "CHATBOT_POLICY"
       ]
     },
     "Content": {

--- a/aws-organizations-policy/docs/README.md
+++ b/aws-organizations-policy/docs/README.md
@@ -57,13 +57,13 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Type
 
-The type of policy to create. You can specify one of the following values: AISERVICES_OPT_OUT_POLICY, BACKUP_POLICY, SERVICE_CONTROL_POLICY, TAG_POLICY
+The type of policy to create. You can specify one of the following values: AISERVICES_OPT_OUT_POLICY, BACKUP_POLICY, SERVICE_CONTROL_POLICY, TAG_POLICY, CHATBOT_POLICY
 
 _Required_: Yes
 
 _Type_: String
 
-_Allowed Values_: <code>SERVICE_CONTROL_POLICY</code> | <code>AISERVICES_OPT_OUT_POLICY</code> | <code>BACKUP_POLICY</code> | <code>TAG_POLICY</code>
+_Allowed Values_: <code>SERVICE_CONTROL_POLICY</code> | <code>AISERVICES_OPT_OUT_POLICY</code> | <code>BACKUP_POLICY</code> | <code>TAG_POLICY</code> | <code>CHATBOT_POLICY</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/PolicyConstants.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/PolicyConstants.java
@@ -6,7 +6,8 @@ public class PolicyConstants {
         AISERVICES_OPT_OUT_POLICY("AISERVICES_OPT_OUT_POLICY"),
         BACKUP_POLICY("BACKUP_POLICY"),
         SERVICE_CONTROL_POLICY("SERVICE_CONTROL_POLICY"),
-        TAG_POLICY("TAG_POLICY");
+        TAG_POLICY("TAG_POLICY"),
+        CHATBOT_POLICY("CHATBOT_POLICY");
 
         private final String policyType;
 

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
@@ -49,7 +49,7 @@ public class AbstractTestBase {
     protected static final Set<String> TEST_TARGET_IDS = ImmutableSet.of(TEST_TARGET_ROOT_ID, TEST_TARGET_OU_ID);
     protected static final Set<String> TEST_UPDATED_TARGET_IDS = ImmutableSet.of(TEST_TARGET_ROOT_ID, TEST_TARGET_ACCOUNT_ID);
     protected static final String TEST_NEXT_TOKEN = "mockNextTokenItem";
-    protected static final String POLICY_SCHEMA_SHA256_HEXSTRING = "A562D1A859C2312EDE249C91077773796CD3DB7FFD41624D8B3D0D3C7481D6AA";
+    protected static final String POLICY_SCHEMA_SHA256_HEXSTRING = "2D6EC3A321FCB847C3D82D496E0E831B047C74ABE67B4E797CB9C30DD1E149DF";
     protected static final String POLICY_JSON_SCHEMA_FILE_NAME = "aws-organizations-policy.json";
 
     protected static final Credentials MOCK_CREDENTIALS;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Add support for `CHATBOT_POLICY` policy type. 

Tested by registering resource changes in private resource and creating/updating/deleting a stack that created a CHATBOT_POLICY and attached it to an OU via CFN.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
