### PR TITLE
Add support for new policy type RESOURCE_CONTROL_POLICY

### DIFF
--- a/aws-organizations-policy/aws-organizations-policy.json
+++ b/aws-organizations-policy/aws-organizations-policy.json
@@ -11,7 +11,7 @@
       "maxLength": 128
     },
     "Type": {
-      "description": "The type of policy to create. You can specify one of the following values: AISERVICES_OPT_OUT_POLICY, BACKUP_POLICY, SERVICE_CONTROL_POLICY, TAG_POLICY, CHATBOT_POLICY",
+      "description": "The type of policy to create. You can specify one of the following values: AISERVICES_OPT_OUT_POLICY, BACKUP_POLICY, SERVICE_CONTROL_POLICY, TAG_POLICY, CHATBOT_POLICY, RESOURCE_CONTROL_POLICY"
       "type": "string",
       "enum": [
         "SERVICE_CONTROL_POLICY",

--- a/aws-organizations-policy/aws-organizations-policy.json
+++ b/aws-organizations-policy/aws-organizations-policy.json
@@ -11,7 +11,7 @@
       "maxLength": 128
     },
     "Type": {
-      "description": "The type of policy to create. You can specify one of the following values: AISERVICES_OPT_OUT_POLICY, BACKUP_POLICY, SERVICE_CONTROL_POLICY, TAG_POLICY, CHATBOT_POLICY, RESOURCE_CONTROL_POLICY"
+      "description": "The type of policy to create. You can specify one of the following values: AISERVICES_OPT_OUT_POLICY, BACKUP_POLICY, SERVICE_CONTROL_POLICY, TAG_POLICY, CHATBOT_POLICY, RESOURCE_CONTROL_POLICY",
       "type": "string",
       "enum": [
         "SERVICE_CONTROL_POLICY",

--- a/aws-organizations-policy/aws-organizations-policy.json
+++ b/aws-organizations-policy/aws-organizations-policy.json
@@ -18,7 +18,8 @@
         "AISERVICES_OPT_OUT_POLICY",
         "BACKUP_POLICY",
         "TAG_POLICY",
-        "CHATBOT_POLICY"
+        "CHATBOT_POLICY",
+        "RESOURCE_CONTROL_POLICY"
       ]
     },
     "Content": {

--- a/aws-organizations-policy/docs/README.md
+++ b/aws-organizations-policy/docs/README.md
@@ -57,7 +57,7 @@ _Update requires_: [No interruption](https://docs.aws.amazon.com/AWSCloudFormati
 
 #### Type
 
-The type of policy to create. You can specify one of the following values: AISERVICES_OPT_OUT_POLICY, BACKUP_POLICY, SERVICE_CONTROL_POLICY, TAG_POLICY, CHATBOT_POLICY
+The type of policy to create. You can specify one of the following values: AISERVICES_OPT_OUT_POLICY, BACKUP_POLICY, SERVICE_CONTROL_POLICY, TAG_POLICY, CHATBOT_POLICY, RESOURCE_CONTROL_POLICY
 
 _Required_: Yes
 

--- a/aws-organizations-policy/docs/README.md
+++ b/aws-organizations-policy/docs/README.md
@@ -63,7 +63,7 @@ _Required_: Yes
 
 _Type_: String
 
-_Allowed Values_: <code>SERVICE_CONTROL_POLICY</code> | <code>AISERVICES_OPT_OUT_POLICY</code> | <code>BACKUP_POLICY</code> | <code>TAG_POLICY</code> | <code>CHATBOT_POLICY</code>
+_Allowed Values_: <code>SERVICE_CONTROL_POLICY</code> | <code>AISERVICES_OPT_OUT_POLICY</code> | <code>BACKUP_POLICY</code> | <code>TAG_POLICY</code> | <code>CHATBOT_POLICY</code> | <code>RESOURCE_CONTROL_POLICY</code>
 
 _Update requires_: [Replacement](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-update-behaviors.html#update-replacement)
 

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/PolicyConstants.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/PolicyConstants.java
@@ -7,7 +7,8 @@ public class PolicyConstants {
         BACKUP_POLICY("BACKUP_POLICY"),
         SERVICE_CONTROL_POLICY("SERVICE_CONTROL_POLICY"),
         TAG_POLICY("TAG_POLICY"),
-        CHATBOT_POLICY("CHATBOT_POLICY");
+        CHATBOT_POLICY("CHATBOT_POLICY"),
+        RESOURCE_CONTROL_POLICY("RESOURCE_CONTROL_POLICY");
 
         private final String policyType;
 

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
@@ -49,7 +49,7 @@ public class AbstractTestBase {
     protected static final Set<String> TEST_TARGET_IDS = ImmutableSet.of(TEST_TARGET_ROOT_ID, TEST_TARGET_OU_ID);
     protected static final Set<String> TEST_UPDATED_TARGET_IDS = ImmutableSet.of(TEST_TARGET_ROOT_ID, TEST_TARGET_ACCOUNT_ID);
     protected static final String TEST_NEXT_TOKEN = "mockNextTokenItem";
-    protected static final String POLICY_SCHEMA_SHA256_HEXSTRING = "05B235E4D98BCD33B4BBD400B693EF938899CABA1F8EB6359BA50B663D96B90D";
+    protected static final String POLICY_SCHEMA_SHA256_HEXSTRING = "82F7D81E3153063EFDB101473B21E54C9722DED9EDFA270D59390F711ACD6B24";
     protected static final String POLICY_JSON_SCHEMA_FILE_NAME = "aws-organizations-policy.json";
 
     protected static final Credentials MOCK_CREDENTIALS;

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
@@ -49,7 +49,7 @@ public class AbstractTestBase {
     protected static final Set<String> TEST_TARGET_IDS = ImmutableSet.of(TEST_TARGET_ROOT_ID, TEST_TARGET_OU_ID);
     protected static final Set<String> TEST_UPDATED_TARGET_IDS = ImmutableSet.of(TEST_TARGET_ROOT_ID, TEST_TARGET_ACCOUNT_ID);
     protected static final String TEST_NEXT_TOKEN = "mockNextTokenItem";
-    protected static final String POLICY_SCHEMA_SHA256_HEXSTRING = "570EA2A5670352042505D77D1921807BDD013D474A62202278E616BC94423BF0";
+    protected static final String POLICY_SCHEMA_SHA256_HEXSTRING = "05B235E4D98BCD33B4BBD400B693EF938899CABA1F8EB6359BA50B663D96B90D";
     protected static final String POLICY_JSON_SCHEMA_FILE_NAME = "aws-organizations-policy.json";
 
     protected static final Credentials MOCK_CREDENTIALS;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add support for RESOURCE_CONTROL_POLICY policy type.

Tested by registering resource changes in private resource and creating/updating/deleting a stack that created a RESOURCE_CONTROL_POLICY and attached it to an OU via CFN.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
