### PR TITLE
Implementation of Idempotency for Account Resource Handler

### DIFF
--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/CallbackContext.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/CallbackContext.java
@@ -20,7 +20,9 @@ public class CallbackContext extends StdCallbackContext {
         this.actionToRetryAttemptMap.put(key, getCurrentRetryAttempt(actionName, handlerName)+1);
     }
     // used in CREATE handler
+    private boolean isPreExistingResourceChecked = false;
     private boolean isAccountCreated = false;
     private String createAccountRequestId;
     private String failureReason;
+    private String generatedAccountId;
 }

--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/CreateHandler.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/CreateHandler.java
@@ -2,6 +2,8 @@ package software.amazon.organizations.account;
 
 import org.apache.commons.collections4.CollectionUtils;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
+import software.amazon.awssdk.services.organizations.model.Account;
+import software.amazon.awssdk.services.organizations.model.ListAccountsResponse;
 import software.amazon.awssdk.services.organizations.model.CreateAccountRequest;
 import software.amazon.awssdk.services.organizations.model.CreateAccountResponse;
 import software.amazon.awssdk.services.organizations.model.DescribeCreateAccountStatusResponse;
@@ -12,12 +14,16 @@ import software.amazon.awssdk.services.organizations.model.MoveAccountRequest;
 import software.amazon.awssdk.services.organizations.model.MoveAccountResponse;
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
 import software.amazon.cloudformation.proxy.HandlerErrorCode;
+import software.amazon.cloudformation.proxy.OperationStatus;
 import software.amazon.cloudformation.proxy.ProgressEvent;
 import software.amazon.cloudformation.proxy.ProxyClient;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.organizations.utils.OrgsLoggerWrapper;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.cloudformation.exceptions.CfnAlreadyExistsException;
 
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 
 public class CreateHandler extends BaseHandlerStd {
     private OrgsLoggerWrapper log;
@@ -47,27 +53,93 @@ public class CreateHandler extends BaseHandlerStd {
         }
 
         return ProgressEvent.progress(request.getDesiredResourceState(), callbackContext)
-                   .then(progress -> {
-                           if (progress.getCallbackContext().isAccountCreated()) {
-                               log.log(String.format("Account has already been created in previous handler invoke with account Id: [%s]. Skip create account.", model.getAccountId()));
-                               return ProgressEvent.progress(model, callbackContext);
-                           }
-                           return awsClientProxy.initiate("AWS-Organizations-Account::CreateAccount", orgsClient, progress.getResourceModel(), progress.getCallbackContext())
-                                      .translateToServiceRequest(Translator::translateToCreateAccountRequest)
-                                      .makeServiceCall(this::createAccount)
-                                      .handleError((organizationsRequest, e, proxyClient1, model1, context) -> handleError(organizationsRequest, request, e, proxyClient1, model1, context, logger))
-                                      .done(CreateAccountResponse -> {
-                                          callbackContext.setCreateAccountRequestId(CreateAccountResponse.createAccountStatus().id());
-                                          logger.log(String.format("Successfully initiated new account creation request with CreateAccountRequestId [%s]", callbackContext.getCreateAccountRequestId()));
-                                          return ProgressEvent.progress(model, callbackContext);
-                                      });
-                       }
-
-                   )
+                   .then(progress -> checkForExistingResource(awsClientProxy, orgsClient, progress, request, logger))
+                   .then(progress -> createResourceIfNeeded(awsClientProxy, orgsClient, progress, request, logger))
                    .then(progress -> describeCreateAccountStatus(awsClientProxy, request, model, callbackContext, orgsClient, logger))
                    .then(progress -> moveAccount(awsClientProxy, request, model, callbackContext, orgsClient, logger))
                    .then(progress -> ProgressEvent.success(progress.getResourceModel(), progress.getCallbackContext()));
     }
+
+    protected ProgressEvent<ResourceModel, CallbackContext> checkForExistingResource(
+            final AmazonWebServicesClientProxy proxy,
+            final ProxyClient<OrganizationsClient> proxyClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final OrgsLoggerWrapper logger
+    ) {
+        CallbackContext context = progress.getCallbackContext();
+        ResourceModel model = progress.getResourceModel();
+
+        context.setPreExistingResourceChecked(true);
+        if (!StringUtils.isBlank(context.getGeneratedAccountId())) {
+            return progress;
+        }
+
+        return proxy.initiate("AWS-Organizations-Account::ListAccounts::PreCreate", proxyClient,
+                        progress.getResourceModel(), progress.getCallbackContext())
+                .translateToServiceRequest(t -> Translator.translateToListAccounts(request.getNextToken()))
+                .makeServiceCall((listAccountsRequest, client) -> {
+                    try {
+                        ListAccountsResponse response = client.injectCredentialsAndInvokeV2(listAccountsRequest, client.client()::listAccounts);
+                        for (Account account : response.accounts()) {
+                            if (account.email().equals(model.getEmail())) {
+                                model.setAccountId(account.id());
+                                context.setAccountCreated(true);
+                                context.setGeneratedAccountId(account.id());
+                                logger.log(String.format("Account with email [%s] already exists with ID [%s]", model.getEmail(), account.id()));
+                                throw new CfnAlreadyExistsException("AWS::Organizations::Account", model.getEmail());
+                            }
+                        }
+                    } catch (Exception e) {
+                        logger.log("No existing account found");
+                    }
+                    return ListAccountsResponse.builder().build();
+                })
+                .handleError((ResourceHandlerRequest, exception, proxyClient1, resourceModel, callbackContext) -> {
+                    if (exception instanceof AwsServiceException) {
+                        if (((AwsServiceException) exception).isThrottlingException()) {
+                            callbackContext.setPreExistingResourceChecked(false);
+                            return ProgressEvent.<ResourceModel, CallbackContext>builder()
+                                    .status(OperationStatus.IN_PROGRESS)
+                                    .errorCode(HandlerErrorCode.Throttling)
+                                    .callbackContext(callbackContext)
+                                    .resourceModel(resourceModel)
+                                    .callbackDelaySeconds(3)
+                                    .build();
+                        }
+                    }
+                    return handleError(request, resourceModel, callbackContext, exception, logger);
+                })
+                .progress();
+    }
+
+    private ProgressEvent<ResourceModel, CallbackContext> createResourceIfNeeded(
+            final AmazonWebServicesClientProxy awsClientProxy,
+            final ProxyClient<OrganizationsClient> orgsClient,
+            final ProgressEvent<ResourceModel, CallbackContext> progress,
+            final ResourceHandlerRequest<ResourceModel> request,
+            final OrgsLoggerWrapper logger) {
+
+        ResourceModel model = progress.getResourceModel();
+        CallbackContext context = progress.getCallbackContext();
+
+        if (context.isAccountCreated()) {
+            logger.log(String.format("Account has already been created with ID: [%s]. Skipping creation.", context.getGeneratedAccountId()));
+            return progress;
+        }
+
+        return awsClientProxy.initiate("AWS-Organizations-Account::CreateAccount", orgsClient, model, context)
+                .translateToServiceRequest(Translator::translateToCreateAccountRequest)
+                .makeServiceCall(this::createAccount)
+                .handleError((organizationsRequest, e, proxyClient1, model1, context1) ->
+                        handleError(organizationsRequest, request, e, proxyClient1, model1, context1, logger))
+                .done(createAccountResponse -> {
+                    context.setCreateAccountRequestId(createAccountResponse.createAccountStatus().id());
+                    logger.log(String.format("Successfully initiated new account creation request with CreateAccountRequestId [%s]", context.getCreateAccountRequestId()));
+                    return ProgressEvent.progress(model, context);
+                });
+    }
+
 
     protected ProgressEvent<ResourceModel, CallbackContext> describeCreateAccountStatus(
         final AmazonWebServicesClientProxy awsClientProxy,


### PR DESCRIPTION
*Issue #*

*Description of changes:* Implemented Idempotency by checking if the provided email is already there for any of our accounts, if yes then will set the flag ' PreExistingResourceChecked ' to true else it would be false(as it is intiated), we use method `checkForExistingResource` to do this, we use method `createResourceIfNeeded` to check whether to create the account or not

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
