### PR TITLE
Updating OrganizationalUnit create and update handlers to support stack tags

### DIFF
--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/CreateHandler.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/CreateHandler.java
@@ -31,7 +31,7 @@ public class CreateHandler extends BaseHandlerStd {
         return ProgressEvent.progress(model, callbackContext)
                    .then(progress ->
                              awsClientProxy.initiate("AWS-Organizations-OrganizationalUnit::CreateOrganizationalUnit", orgsClient, progress.getResourceModel(), progress.getCallbackContext())
-                                 .translateToServiceRequest(Translator::translateToCreateOrganizationalUnitRequest)
+                                 .translateToServiceRequest(x -> Translator.translateToCreateOrganizationalUnitRequest(x, request))
                                  .makeServiceCall(this::createOrganizationalUnit)
                                  .stabilize(this::stabilized)
                                  .handleError((organizationsRequest, e, proxyClient1, model1, context) ->

--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/TagsHelper.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/TagsHelper.java
@@ -1,0 +1,61 @@
+package software.amazon.organizations.organizationalunit;
+
+import com.google.common.collect.Sets;
+import software.amazon.awssdk.services.organizations.model.Tag;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TagsHelper {
+
+    static Set<Tag> convertOrganizationalUnitTagToOrganizationTag(final Set<software.amazon.organizations.organizationalunit.Tag> tags) {
+        final Set<Tag> tagsToReturn = new HashSet<>();
+        if (tags != null) {
+            for (software.amazon.organizations.organizationalunit.Tag inputTag : tags) {
+                Tag tag = buildTag(inputTag.getKey(), inputTag.getValue());
+                tagsToReturn.add(tag);
+            }
+        }
+        return tagsToReturn;
+    }
+
+    static Set<String> getTagKeysToRemove(
+            Set<Tag> oldTags, Set<Tag> newTags) {
+        final Set<String> oldTagKeys = getTagKeySet(oldTags);
+        final Set<String> newTagKeys = getTagKeySet(newTags);
+        return Sets.difference(oldTagKeys, newTagKeys);
+    }
+
+    private static Set<String> getTagKeySet(Set<Tag> oldTags) {
+        return oldTags.stream().map(Tag::key).collect(Collectors.toSet());
+    }
+
+    static Set<Tag> getTagsToAddOrUpdate(
+            Set<Tag> oldTags, Set<Tag> newTags) {
+        return Sets.difference(newTags, oldTags);
+    }
+
+    static Set<Tag> mergeTags(final Set<Tag> resourceTags, final Map<String, String> desiredResourceTags) {
+        final Set<Tag> result = (resourceTags == null) ? new HashSet<>() : new HashSet<>(resourceTags);
+        if (desiredResourceTags != null) {
+            result.addAll(tagMapToTagSetConverter(desiredResourceTags));
+        }
+        return result;
+    }
+
+    private static Set<Tag> tagMapToTagSetConverter(final Map<String, String> map) {
+        return map.entrySet()
+                .stream()
+                .map(entry -> buildTag(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toSet());
+    }
+
+    static Tag buildTag(String key, String value) {
+        return Tag.builder()
+                .key(key)
+                .value(value)
+                .build();
+    }
+}

--- a/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/CreateHandlerTest.java
+++ b/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/CreateHandlerTest.java
@@ -33,6 +33,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static software.amazon.organizations.organizationalunit.TagTestResourcesHelper.defaultStackTags;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -62,6 +63,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .desiredResourceTags(defaultStackTags)
             .build();
 
         final CreateOrganizationalUnitResponse createOrganizationalUnitResponse = getCreateOrganizationalUnitResponse();
@@ -83,7 +85,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getName()).isEqualTo(TEST_OU_NAME);
         assertThat(response.getResourceModel().getArn()).isEqualTo(TEST_OU_ARN);
         assertThat(response.getResourceModel().getId()).isEqualTo(TEST_OU_ID);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertOrganizationalUnitTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
@@ -126,6 +130,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .desiredResourceTags(defaultStackTags)
             .build();
 
         when(mockProxyClient.client().createOrganizationalUnit(any(CreateOrganizationalUnitRequest.class))).thenThrow(DuplicateOrganizationalUnitException.class);

--- a/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/ReadHandlerTest.java
+++ b/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/ReadHandlerTest.java
@@ -99,7 +99,9 @@ public class ReadHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getName()).isEqualTo(TEST_OU_NAME);
         assertThat(response.getResourceModel().getArn()).isEqualTo(TEST_OU_ARN);
         assertThat(response.getResourceModel().getId()).isEqualTo(TEST_OU_ID);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertOrganizationalUnitTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();

--- a/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/UpdateHandlerTest.java
+++ b/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/UpdateHandlerTest.java
@@ -1,9 +1,7 @@
 package software.amazon.organizations.organizationalunit;
 
 import java.time.Duration;
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
@@ -89,12 +87,12 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final Set<Tag> oldTags = TagsHelper.mergeTags(
                 TagsHelper.convertOrganizationalUnitTagToOrganizationTag(previousResourceModel.getTags()),
-                TagTestResourcesHelper.defaultStackTags
+                request.getPreviousResourceTags()
         );
 
         final Set<Tag> newTags = TagsHelper.mergeTags(
                 TagsHelper.convertOrganizationalUnitTagToOrganizationTag(model.getTags()),
-                TagTestResourcesHelper.updatedStackTags
+                request.getDesiredResourceTags()
         );
 
         final Set<Tag> tagsToAddOrUpdate = TagsHelper.getTagsToAddOrUpdate(oldTags, newTags);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add support to create and update stack tags to OrganizationalUnit (OU) CloudFormation stacks by updating the OU create and update handlers.
* Update OU create and update handler tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
