### PR TITLE
Updating Policy create and update handlers to support stack tags

### DIFF
--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/CreateHandler.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/CreateHandler.java
@@ -54,7 +54,7 @@ public class CreateHandler extends BaseHandlerStd {
                     return ProgressEvent.progress(model, callbackContext);
                 }
                 return awsClientProxy.initiate("AWS-Organizations-Policy::CreatePolicy", orgsClient, progress.getResourceModel(), progress.getCallbackContext())
-                    .translateToServiceRequest(Translator::translateToCreateRequest)
+                    .translateToServiceRequest(x -> Translator.translateToCreateRequest(x, request))
                     .makeServiceCall(this::createPolicy)
                     .handleError((organizationsRequest, e, proxyClient1, model1, context) ->
                                      handleError(organizationsRequest, e, proxyClient1, model1, context, logger))

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/TagsHelper.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/TagsHelper.java
@@ -1,0 +1,61 @@
+package software.amazon.organizations.policy;
+
+import com.google.common.collect.Sets;
+import software.amazon.awssdk.services.organizations.model.Tag;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TagsHelper {
+
+    static Set<Tag> convertPolicyTagToOrganizationTag(final Set<software.amazon.organizations.policy.Tag> tags) {
+        final Set<Tag> tagsToReturn = new HashSet<>();
+        if (tags != null) {
+            for (software.amazon.organizations.policy.Tag inputTag : tags) {
+                Tag tag = buildTag(inputTag.getKey(), inputTag.getValue());
+                tagsToReturn.add(tag);
+            }
+        }
+        return tagsToReturn;
+    }
+
+    static Set<String> getTagKeysToRemove(
+            Set<Tag> oldTags, Set<Tag> newTags) {
+        final Set<String> oldTagKeys = getTagKeySet(oldTags);
+        final Set<String> newTagKeys = getTagKeySet(newTags);
+        return Sets.difference(oldTagKeys, newTagKeys);
+    }
+
+    private static Set<String> getTagKeySet(Set<Tag> oldTags) {
+        return oldTags.stream().map(Tag::key).collect(Collectors.toSet());
+    }
+
+    static Set<Tag> getTagsToAddOrUpdate(
+            Set<Tag> oldTags, Set<Tag> newTags) {
+        return Sets.difference(newTags, oldTags);
+    }
+
+    static Set<Tag> mergeTags(final Set<Tag> resourceTags, final Map<String, String> desiredResourceTags) {
+        final Set<Tag> result = (resourceTags == null) ? new HashSet<>() : new HashSet<>(resourceTags);
+        if (desiredResourceTags != null) {
+            result.addAll(tagMapToTagSetConverter(desiredResourceTags));
+        }
+        return result;
+    }
+
+    private static Set<Tag> tagMapToTagSetConverter(final Map<String, String> map) {
+        return map.entrySet()
+                .stream()
+                .map(entry -> buildTag(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toSet());
+    }
+
+    static Tag buildTag(String key, String value) {
+        return Tag.builder()
+                .key(key)
+                .value(value)
+                .build();
+    }
+}

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/Translator.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/Translator.java
@@ -16,6 +16,7 @@ import software.amazon.awssdk.services.organizations.model.UpdatePolicyRequest;
 import software.amazon.cloudformation.exceptions.CfnHandlerInternalFailureException;
 import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -27,6 +28,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static software.amazon.organizations.policy.TagsHelper.buildTag;
+
 /**
  * This class is a centralized placeholder for
  * - api request construction
@@ -36,9 +39,9 @@ import java.util.stream.Stream;
 public class Translator {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    static CreatePolicyRequest translateToCreateRequest(final ResourceModel model) {
+    static CreatePolicyRequest translateToCreateRequest(final ResourceModel model, final ResourceHandlerRequest<ResourceModel> request) {
         String content = convertObjectToString(model.getContent());
-        if (model.getTags() == null) {
+        if (model.getTags() == null && request.getDesiredResourceTags() == null) {
             return CreatePolicyRequest.builder()
                 .content(content)
                 .description(getOptionalDescription(model))
@@ -46,17 +49,13 @@ public class Translator {
                 .type(model.getType())
                 .build();
         }
-        // convert type
-        List<Tag> tags = new ArrayList<>();
-        model.getTags().forEach(tag -> {
-            tags.add(Tag.builder().key(tag.getKey()).value(tag.getValue()).build());
-        });
+
         return CreatePolicyRequest.builder()
             .content(content)
             .description(getOptionalDescription(model))
             .name(model.getName())
             .type(model.getType())
-            .tags(tags)
+            .tags(translateTagsForTagResourceRequest(model.getTags(), request.getDesiredResourceTags()))
             .build();
     }
 
@@ -95,6 +94,20 @@ public class Translator {
 
     static ListTagsForResourceRequest translateToListTagsForResourceRequest(final String policyId) {
         return ListTagsForResourceRequest.builder().resourceId(policyId).build();
+    }
+
+    static Collection<Tag> translateTagsForTagResourceRequest(Set<software.amazon.organizations.policy.Tag> tags, Map<String, String> desiredResourceTags) {
+        final Collection<Tag> tagsToReturn = new ArrayList<>();
+
+        if (tags != null) {
+            tags.forEach(tag -> tagsToReturn.add(buildTag(tag.getKey(), tag.getValue())));
+        }
+
+        if (desiredResourceTags != null) {
+            desiredResourceTags.forEach((key, value) -> tagsToReturn.add(buildTag(key, value)));
+        }
+
+        return tagsToReturn;
     }
 
     static Set<software.amazon.organizations.policy.Tag> translateTagsFromSdkResponse(List<Tag> inputTags) {

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/UpdateHandler.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/UpdateHandler.java
@@ -1,6 +1,5 @@
 package software.amazon.organizations.policy;
 
-import com.google.common.collect.Sets;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import software.amazon.awssdk.services.organizations.model.AttachPolicyRequest;
 import software.amazon.awssdk.services.organizations.model.DetachPolicyRequest;
@@ -21,10 +20,8 @@ import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 import software.amazon.organizations.utils.OrgsLoggerWrapper;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
- import java.util.stream.Collectors;
 
 public class UpdateHandler extends BaseHandlerStd {
     private OrgsLoggerWrapper log;
@@ -64,6 +61,17 @@ public class UpdateHandler extends BaseHandlerStd {
 
         logger.log(String.format("Entered %s update handler with account Id [%s], with Content [%s], Description [%s], Name [%s], Type [%s]",
             ResourceModel.TYPE_NAME, request.getAwsAccountId(), content, model.getDescription(), model.getName(), model.getType()));
+
+        Set<software.amazon.organizations.policy.Tag> previousTags = previousModel.getTags();
+        Set<Tag> allPreviousTags = TagsHelper.mergeTags(
+                TagsHelper.convertPolicyTagToOrganizationTag(previousTags),
+                request.getPreviousResourceTags());
+
+        Set<software.amazon.organizations.policy.Tag> newTags = model.getTags();
+        Set<Tag> allNewTags = TagsHelper.mergeTags(
+                TagsHelper.convertPolicyTagToOrganizationTag(newTags),
+                request.getDesiredResourceTags());
+
         return ProgressEvent.progress(model, callbackContext)
             .then(progress ->{
                     if (progress.getCallbackContext().isPolicyUpdated()) {
@@ -84,10 +92,7 @@ public class UpdateHandler extends BaseHandlerStd {
 
             )
             .then(progress -> handleTargets(request, awsClientProxy, model, callbackContext, request.getDesiredResourceState().getTargetIds(), request.getPreviousResourceState().getTargetIds(), policyId, orgsClient, logger))
-            .then(progress -> handleTagging(awsClientProxy, model, callbackContext,
-                                    convertPolicyTagToOrganizationTag(model.getTags()),
-                                    convertPolicyTagToOrganizationTag(previousModel.getTags()),
-                                    policyId, orgsClient, logger))
+            .then(progress -> handleTagging(awsClientProxy, model, callbackContext, allNewTags, allPreviousTags, policyId, orgsClient, logger))
             .then(progress -> new ReadHandler().handleRequest(awsClientProxy, request, callbackContext, orgsClient, logger));
     }
 
@@ -174,17 +179,17 @@ public class UpdateHandler extends BaseHandlerStd {
             final AmazonWebServicesClientProxy awsClientProxy,
             final ResourceModel model,
             final CallbackContext callbackContext,
-            final Set<Tag> desiredTags,
+            final Set<Tag> newTags,
             final Set<Tag> previousTags,
             final String policyId,
             final ProxyClient<OrganizationsClient> orgsClient,
             final OrgsLoggerWrapper logger
     ) {
         // Includes all old tags that do not exist in new tag list
-        final Set<String> tagsToRemove = getTagKeysToRemove(previousTags, desiredTags);
+        final Set<String> tagsToRemove = TagsHelper.getTagKeysToRemove(previousTags, newTags);
 
         // Excluded all old tags that do exist in new tag list
-        final Set<Tag> tagsToAddOrUpdate = getTagsToAddOrUpdate(previousTags, desiredTags);
+        final Set<Tag> tagsToAddOrUpdate = TagsHelper.getTagsToAddOrUpdate(previousTags, newTags);
 
         // Delete tags only if tagsToRemove is not empty
         if (!tagsToRemove.isEmpty()) {
@@ -209,35 +214,6 @@ public class UpdateHandler extends BaseHandlerStd {
         }
 
         return ProgressEvent.progress(model, callbackContext);
-    }
-
-    static Set<Tag> convertPolicyTagToOrganizationTag(final Set<software.amazon.organizations.policy.Tag> tags) {
-        final Set<Tag> tagsToReturn = new HashSet<>();
-        if (tags == null) return tagsToReturn;
-        for (software.amazon.organizations.policy.Tag inputTag : tags) {
-            Tag tag = Tag.builder()
-                .key(inputTag.getKey())
-                .value(inputTag.getValue())
-                .build();
-            tagsToReturn.add(tag);
-        }
-        return tagsToReturn;
-    }
-
-    static Set<String> getTagKeysToRemove(
-           Set<Tag> oldTags, Set<Tag> newTags) {
-        final Set<String> oldTagKeys = getTagKeySet(oldTags);
-        final Set<String> newTagKeys = getTagKeySet(newTags);
-        return Sets.difference(oldTagKeys, newTagKeys);
-    }
-
-    static Set<String> getTagKeySet(Set<Tag> oldTags) {
-        return oldTags.stream().map(Tag::key).collect(Collectors.toSet());
-    }
-
-    static Set<Tag> getTagsToAddOrUpdate(
-           Set<Tag> oldTags, Set<Tag> newTags) {
-        return Sets.difference(newTags, oldTags);
     }
 
 }

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
@@ -274,6 +274,10 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
+        assertThat(TagTestResourceHelper.tagsEqual(
+                TagsHelper.convertPolicyTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourceHelper.defaultTags)).isTrue();
+
         verify(mockProxyClient.client()).createPolicy(any(CreatePolicyRequest.class));
         verify(mockProxyClient.client(), times(2)).attachPolicy(any(AttachPolicyRequest.class));
         verify(mockProxyClient.client()).describePolicy(any(DescribePolicyRequest.class));

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
@@ -44,6 +44,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static software.amazon.organizations.policy.TagTestResourceHelper.defaultStackTags;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -236,6 +237,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .desiredResourceTags(defaultStackTags)
             .build();
 
         final CreatePolicyResponse createPolicyResponse = getCreatePolicyResponse();
@@ -288,6 +290,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final CreatePolicyResponse createPolicyResponse = getCreatePolicyResponse();
@@ -413,6 +416,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .desiredResourceTags(defaultStackTags)
             .build();
 
         when(mockProxyClient.client().createPolicy(any(CreatePolicyRequest.class))).thenThrow(DuplicatePolicyException.class);

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/TagTestResourceHelper.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/TagTestResourceHelper.java
@@ -1,12 +1,12 @@
 package software.amazon.organizations.policy;
 
+import com.google.common.collect.ImmutableMap;
 import software.amazon.awssdk.services.organizations.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.organizations.model.Tag;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class TagTestResourceHelper {
@@ -28,6 +28,11 @@ public class TagTestResourceHelper {
         CHANGING_TAG_UPDATED,
         ADDED_TAG
     ));
+
+    final static Map<String, String> defaultStackTags = ImmutableMap.of(
+            "StackTagKey1", "StackTagValue1", "StackTagKey2", "StackTagValue2");
+    final static Map<String, String> updatedStackTags = ImmutableMap.of(
+            "StackTagKey1", "StackTagValue3", "StackTagKey4", "StackTagValue4");
 
     static ListTagsForResourceResponse buildDefaultTagsResponse() {
         return ListTagsForResourceResponse.builder()
@@ -84,18 +89,12 @@ public class TagTestResourceHelper {
         return set1.equals(set2);
     }
 
-    static boolean correctTagsInTagAndUntagRequests(Set<Tag> tagsToAddOrUpdate, Set<String> tagsToRemove) {
+    static boolean correctTagsInTagAndUntagRequests(Set<Tag> tagsToAddOrUpdate, Set<String> tagsToRemoveKeys) {
         boolean correctTagsInRequests = true;
 
         Set<String> tagsToAddOrUpdateKeys = new HashSet<>();
-        Set<String> tagsToRemoveKeys = new HashSet<>();
-
         for (Tag tag : tagsToAddOrUpdate) {
             tagsToAddOrUpdateKeys.add(tag.key());
-        }
-
-        for (String key : tagsToRemove) {
-            tagsToRemoveKeys.add(key);
         }
 
         // Constant tag should be in neither tagsToAddOrUpdate nor tagsToRemove
@@ -103,18 +102,21 @@ public class TagTestResourceHelper {
             correctTagsInRequests = false;
         }
 
-        // Delete tag should be the single item in tagsToRemove
-        if (tagsToAddOrUpdateKeys.contains("Delete") || !tagsToRemoveKeys.contains("Delete") || tagsToRemoveKeys.size() != 1) {
+        // Only Delete and StackTagKey2 tags should be in tagsToRemove
+        if (tagsToAddOrUpdateKeys.contains("Delete") || tagsToAddOrUpdateKeys.contains("StackTagKey2") ||
+                !tagsToRemoveKeys.contains("Delete") || !tagsToRemoveKeys.contains("StackTagKey2") || tagsToRemoveKeys.size() != 2) {
             correctTagsInRequests = false;
         }
 
-        // Update tag should be in tagsToAddOrUpdate not tagsToRemove
-        if (!tagsToAddOrUpdateKeys.contains("Update") || tagsToRemoveKeys.contains("Update")) {
+        // Update and StackTagKey1 tags (getting updated) should be in tagsToAddOrUpdate and not in tagsToRemove
+        if (!tagsToAddOrUpdateKeys.contains("Update") || !tagsToAddOrUpdateKeys.contains("StackTagKey1") ||
+                tagsToRemoveKeys.contains("Update") || tagsToRemoveKeys.contains("StackTagKey1")) {
             correctTagsInRequests = false;
         }
 
-        // Add tag should be in tagsToAddOrUpdate not tagsToRemove
-        if (!tagsToAddOrUpdateKeys.contains("Add") || tagsToRemoveKeys.contains("Add")) {
+        // Add and StackTagKey4 tags (getting added) should be in tagsToAddOrUpdate and not in tagsToRemove
+        if (!tagsToAddOrUpdateKeys.contains("Add") || !tagsToAddOrUpdateKeys.contains("StackTagKey4") ||
+                tagsToRemoveKeys.contains("Add") || tagsToRemoveKeys.contains("StackTagKey4")) {
             correctTagsInRequests = false;
         }
 

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/TagTestResourceHelper.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/TagTestResourceHelper.java
@@ -66,21 +66,6 @@ public class TagTestResourceHelper {
         return tagsToReturn;
     }
 
-    static Set<Tag> translatePolicyTagsToOrganizationTags(Set<software.amazon.organizations.policy.Tag> tags) {
-        if (tags == null) return new HashSet<>();
-
-        final Set<Tag> tagsToReturn = new HashSet<>();
-        for (software.amazon.organizations.policy.Tag inputTags : tags) {
-            Tag tag = Tag.builder()
-                .key(inputTags.getKey())
-                .value(inputTags.getValue())
-                .build();
-            tagsToReturn.add(tag);
-        }
-
-        return tagsToReturn;
-    }
-
     static boolean tagsEqual(Set<?> set1, Set<?> set2){
         if (set1 == null || set2 == null) {
             return false;

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/UpdateHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/UpdateHandlerTest.java
@@ -37,8 +37,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -276,6 +274,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .previousResourceState(initialResourceModel)
             .desiredResourceState(updatedResourceModel)
+            .previousResourceTags(TagTestResourceHelper.defaultStackTags)
+            .desiredResourceTags(TagTestResourceHelper.updatedStackTags)
             .build();
 
         final UpdatePolicyResponse updatePolicyResponse = getUpdatePolicyResponse();
@@ -296,14 +296,18 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ProgressEvent<ResourceModel, CallbackContext> response = updateHandlerToTest.handleRequest(mockAwsClientproxy, request, new CallbackContext(), mockProxyClient, logger);
 
-        final Set<Tag> tagsToAddOrUpdate = UpdateHandler.getTagsToAddOrUpdate(
-            TagTestResourceHelper.translatePolicyTagsToOrganizationTags(initialResourceModel.getTags()),
-            TagTestResourceHelper.translatePolicyTagsToOrganizationTags(updatedResourceModel.getTags()));
-
-        final Set<String> tagKeysToRemove = UpdateHandler.getTagKeysToRemove(
-            TagTestResourceHelper.translatePolicyTagsToOrganizationTags(initialResourceModel.getTags()),
-            TagTestResourceHelper.translatePolicyTagsToOrganizationTags(updatedResourceModel.getTags())
+        final Set<Tag> oldTags = TagsHelper.mergeTags(
+                TagsHelper.convertPolicyTagToOrganizationTag(initialResourceModel.getTags()),
+                TagTestResourceHelper.defaultStackTags
         );
+
+        final Set<Tag> newTags = TagsHelper.mergeTags(
+                TagsHelper.convertPolicyTagToOrganizationTag(updatedResourceModel.getTags()),
+                TagTestResourceHelper.updatedStackTags
+        );
+
+        final Set<Tag> tagsToAddOrUpdate = TagsHelper.getTagsToAddOrUpdate(oldTags, newTags);
+        final Set<String> tagKeysToRemove = TagsHelper.getTagKeysToRemove(oldTags, newTags);
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -311,8 +315,10 @@ public class UpdateHandlerTest extends AbstractTestBase {
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isEqualTo(request.getDesiredResourceState());
         assertThat(response.getResourceModels()).isNull();
-        assertThat(TagTestResourceHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourceHelper.updatedTags));
-        assertThat(TagTestResourceHelper.correctTagsInTagAndUntagRequests(tagsToAddOrUpdate, tagKeysToRemove));
+        assertThat(TagTestResourceHelper.tagsEqual(
+                TagsHelper.convertPolicyTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourceHelper.updatedTags)).isTrue();
+        assertThat(TagTestResourceHelper.correctTagsInTagAndUntagRequests(tagsToAddOrUpdate, tagKeysToRemove)).isTrue();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
 
@@ -395,6 +401,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .previousResourceState(initialResourceModel)
             .desiredResourceState(updatedResourceModel)
+            .previousResourceTags(TagTestResourceHelper.defaultStackTags)
+            .desiredResourceTags(TagTestResourceHelper.updatedStackTags)
             .build();
 
         final UpdatePolicyResponse updatePolicyResponse = getUpdatePolicyResponse();
@@ -425,6 +433,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .previousResourceState(initialResourceModel)
             .desiredResourceState(updatedResourceModel)
+            .previousResourceTags(TagTestResourceHelper.defaultStackTags)
+            .desiredResourceTags(TagTestResourceHelper.updatedStackTags)
             .build();
 
         final UpdatePolicyResponse updatePolicyResponse = getUpdatePolicyResponse();

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/UpdateHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/UpdateHandlerTest.java
@@ -298,12 +298,12 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final Set<Tag> oldTags = TagsHelper.mergeTags(
                 TagsHelper.convertPolicyTagToOrganizationTag(initialResourceModel.getTags()),
-                TagTestResourceHelper.defaultStackTags
+                request.getPreviousResourceTags()
         );
 
         final Set<Tag> newTags = TagsHelper.mergeTags(
                 TagsHelper.convertPolicyTagToOrganizationTag(updatedResourceModel.getTags()),
-                TagTestResourceHelper.updatedStackTags
+                request.getDesiredResourceTags()
         );
 
         final Set<Tag> tagsToAddOrUpdate = TagsHelper.getTagsToAddOrUpdate(oldTags, newTags);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add support to create and update stack tags to Policy CloudFormation stacks by updating the Policy create and update handlers.
* Update Policy create and update handler tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
