### PR TITLE
Updating ResourcePolicy create and update handlers to support stack tags

### DIFF
--- a/aws-organizations-resourcepolicy/src/main/java/software/amazon/organizations/resourcepolicy/CreateHandler.java
+++ b/aws-organizations-resourcepolicy/src/main/java/software/amazon/organizations/resourcepolicy/CreateHandler.java
@@ -47,7 +47,7 @@ public class CreateHandler extends BaseHandlerStd {
             .then(progress -> describeResourcePolicyProgressEvent(awsClientProxy, request, model, callbackContext, orgsClient, logger))
             .then(progress ->
                 awsClientProxy.initiate("AWS-Organizations-ResourcePolicy::CreateResourcePolicy", orgsClient, progress.getResourceModel(), progress.getCallbackContext())
-                    .translateToServiceRequest(Translator::translateToCreateRequest)
+                    .translateToServiceRequest(x -> Translator.translateToCreateRequest(x, request))
                     .makeServiceCall(this::putResourcePolicy)
                     .handleError((organizationsRequest, e, proxyClient1, model1, context) ->
                                     handleErrorInGeneral(organizationsRequest, e, proxyClient1, model1, context, logger, ResourcePolicyConstants.Action.CREATE_RESOURCEPOLICY, ResourcePolicyConstants.Handler.CREATE))

--- a/aws-organizations-resourcepolicy/src/main/java/software/amazon/organizations/resourcepolicy/TagsHelper.java
+++ b/aws-organizations-resourcepolicy/src/main/java/software/amazon/organizations/resourcepolicy/TagsHelper.java
@@ -1,0 +1,63 @@
+package software.amazon.organizations.resourcepolicy;
+
+import com.google.common.collect.Sets;
+import software.amazon.awssdk.services.organizations.model.Tag;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TagsHelper {
+
+    static Set<Tag> convertResourcePolicyTagToOrganizationTag(final Set<software.amazon.organizations.resourcepolicy.Tag> tags) {
+        final Set<Tag> tagsToReturn = new HashSet<>();
+        if (tags == null) return tagsToReturn;
+        for (software.amazon.organizations.resourcepolicy.Tag inputTag : tags) {
+            Tag tag = Tag.builder()
+                    .key(inputTag.getKey())
+                    .value(inputTag.getValue())
+                    .build();
+            tagsToReturn.add(tag);
+        }
+        return tagsToReturn;
+    }
+
+    static Set<String> getTagKeysToRemove(
+            Set<Tag> oldTags, Set<Tag> newTags) {
+        final Set<String> oldTagKeys = getTagKeySet(oldTags);
+        final Set<String> newTagKeys = getTagKeySet(newTags);
+        return Sets.difference(oldTagKeys, newTagKeys);
+    }
+
+    private static Set<String> getTagKeySet(Set<Tag> oldTags) {
+        return oldTags.stream().map(Tag::key).collect(Collectors.toSet());
+    }
+
+    static Set<Tag> getTagsToAddOrUpdate(
+            Set<Tag> oldTags, Set<Tag> newTags) {
+        return Sets.difference(newTags, oldTags);
+    }
+
+    static Set<Tag> mergeTags(final Set<Tag> resourceTags, final Map<String, String> desiredResourceTags) {
+        final Set<Tag> result = (resourceTags == null) ? new HashSet<>() : new HashSet<>(resourceTags);
+        if (desiredResourceTags != null) {
+            result.addAll(tagMapToTagSetConverter(desiredResourceTags));
+        }
+        return result;
+    }
+
+    private static Set<Tag> tagMapToTagSetConverter(final Map<String, String> map) {
+        return map.entrySet()
+                .stream()
+                .map(entry -> buildTag(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toSet());
+    }
+
+    static Tag buildTag(String key, String value) {
+        return Tag.builder()
+                .key(key)
+                .value(value)
+                .build();
+    }
+}

--- a/aws-organizations-resourcepolicy/src/test/java/software/amazon/organizations/resourcepolicy/CreateHandlerTest.java
+++ b/aws-organizations-resourcepolicy/src/test/java/software/amazon/organizations/resourcepolicy/CreateHandlerTest.java
@@ -35,6 +35,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
+import static software.amazon.organizations.resourcepolicy.TagTestResourceHelper.defaultStackTags;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -86,10 +87,11 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_WithTags_SimpleSuccess() {
-        final ResourceModel model = generateInitialResourceModel(false, TEST_RESOURCEPOLICY_CONTENT);
+        final ResourceModel model = generateInitialResourceModel(true, TEST_RESOURCEPOLICY_CONTENT);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .desiredResourceTags(defaultStackTags)
             .build();
 
         final DescribeResourcePolicyResponse describeResourcePolicyResponse = getDescribeResourcePolicyResponse();
@@ -98,11 +100,14 @@ public class CreateHandlerTest extends AbstractTestBase {
         final PutResourcePolicyResponse putResourcePolicyResponse = getPutResourcePolicyResponse();
         when(mockProxyClient.client().putResourcePolicy(any(PutResourcePolicyRequest.class))).thenReturn(putResourcePolicyResponse);
 
-
         final ListTagsForResourceResponse listTagsResponse = TagTestResourceHelper.buildDefaultTagsResponse();
         when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsResponse);
 
         final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+
+        assertThat(TagTestResourceHelper.tagsEqual(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourceHelper.defaultTags)).isTrue();
 
         verifyHandlerSuccess(response, request);
 
@@ -116,10 +121,11 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_WithTags_WithJSONContent_SimpleSuccess() {
-        final ResourceModel model = generateInitialResourceModel(false, TEST_RESOURCEPOLICY_CONTENT_JSON);
+        final ResourceModel model = generateInitialResourceModel(true, TEST_RESOURCEPOLICY_CONTENT_JSON);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .desiredResourceTags(defaultStackTags)
             .build();
 
         final DescribeResourcePolicyResponse describeResourcePolicyResponse = getDescribeResourcePolicyResponse();
@@ -128,11 +134,14 @@ public class CreateHandlerTest extends AbstractTestBase {
         final PutResourcePolicyResponse putResourcePolicyResponse = getPutResourcePolicyResponse();
         when(mockProxyClient.client().putResourcePolicy(any(PutResourcePolicyRequest.class))).thenReturn(putResourcePolicyResponse);
 
-
         final ListTagsForResourceResponse listTagsResponse = TagTestResourceHelper.buildDefaultTagsResponse();
         when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsResponse);
 
         final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+
+        assertThat(TagTestResourceHelper.tagsEqual(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourceHelper.defaultTags)).isTrue();
 
         verifyHandlerSuccess(response, request);
 
@@ -163,10 +172,11 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_Fails_With_CfnAlreadyExistsException() {
-        final ResourceModel model = generateInitialResourceModel(false, TEST_RESOURCEPOLICY_CONTENT);
+        final ResourceModel model = generateInitialResourceModel(true, TEST_RESOURCEPOLICY_CONTENT);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .desiredResourceTags(defaultStackTags)
             .build();
 
         final DescribeResourcePolicyResponse describeResourcePolicyResponse = getDescribeResourcePolicyResponse();
@@ -187,10 +197,11 @@ public class CreateHandlerTest extends AbstractTestBase {
 
     @Test
     public void handleRequest_Fails_With_UnsupportedApiEndpointException() {
-        final ResourceModel model = generateInitialResourceModel(false, TEST_RESOURCEPOLICY_CONTENT);
+        final ResourceModel model = generateInitialResourceModel(true, TEST_RESOURCEPOLICY_CONTENT);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .desiredResourceTags(defaultStackTags)
             .build();
 
         when(mockProxyClient.client().describeResourcePolicy(any(DescribeResourcePolicyRequest.class))).thenThrow(UnsupportedApiEndpointException.class);
@@ -224,10 +235,11 @@ public class CreateHandlerTest extends AbstractTestBase {
     }
 
     private void handleRetriableException(Class<? extends Exception> exception, HandlerErrorCode errorCode) {
-        final ResourceModel model = generateInitialResourceModel(false, TEST_RESOURCEPOLICY_CONTENT);
+        final ResourceModel model = generateInitialResourceModel(true, TEST_RESOURCEPOLICY_CONTENT);
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .desiredResourceState(model)
+            .desiredResourceTags(defaultStackTags)
             .build();
 
         final DescribeResourcePolicyResponse describeResourcePolicyResponse = getDescribeResourcePolicyResponse();

--- a/aws-organizations-resourcepolicy/src/test/java/software/amazon/organizations/resourcepolicy/TagTestResourceHelper.java
+++ b/aws-organizations-resourcepolicy/src/test/java/software/amazon/organizations/resourcepolicy/TagTestResourceHelper.java
@@ -1,10 +1,12 @@
 package software.amazon.organizations.resourcepolicy;
 
+import com.google.common.collect.ImmutableMap;
 import software.amazon.awssdk.services.organizations.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.organizations.model.Tag;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 public class TagTestResourceHelper {
@@ -26,6 +28,11 @@ public class TagTestResourceHelper {
         CHANGING_TAG_UPDATED,
         ADDED_TAG
     ));
+
+    final static Map<String, String> defaultStackTags = ImmutableMap.of(
+            "StackTagKey1", "StackTagValue1", "StackTagKey2", "StackTagValue2");
+    final static Map<String, String> updatedStackTags = ImmutableMap.of(
+            "StackTagKey1", "StackTagValue3", "StackTagKey4", "StackTagValue4");
 
     static ListTagsForResourceResponse buildDefaultTagsResponse() {
         return ListTagsForResourceResponse.builder()
@@ -59,21 +66,6 @@ public class TagTestResourceHelper {
         return tagsToReturn;
     }
 
-    static Set<Tag> translateResourcePolicyTagsToOrganizationTags(Set<software.amazon.organizations.resourcepolicy.Tag> tags) {
-        if (tags == null) return new HashSet<>();
-
-        final Set<Tag> tagsToReturn = new HashSet<>();
-        for (software.amazon.organizations.resourcepolicy.Tag inputTags : tags) {
-            Tag tag = Tag.builder()
-                .key(inputTags.getKey())
-                .value(inputTags.getValue())
-                .build();
-            tagsToReturn.add(tag);
-        }
-
-        return tagsToReturn;
-    }
-
     static boolean tagsEqual(Set<?> set1, Set<?> set2){
         if (set1 == null || set2 == null) {
             return false;
@@ -82,18 +74,13 @@ public class TagTestResourceHelper {
         return set1.equals(set2);
     }
 
-    static boolean correctTagsInTagAndUntagRequests(Set<Tag> tagsToAddOrUpdate, Set<String> tagsToRemove) {
+    static boolean correctTagsInTagAndUntagRequests(Set<Tag> tagsToAddOrUpdate, Set<String> tagsToRemoveKeys) {
         boolean correctTagsInRequests = true;
 
         Set<String> tagsToAddOrUpdateKeys = new HashSet<>();
-        Set<String> tagsToRemoveKeys = new HashSet<>();
 
         for (Tag tag : tagsToAddOrUpdate) {
             tagsToAddOrUpdateKeys.add(tag.key());
-        }
-
-        for (String key : tagsToRemove) {
-            tagsToRemoveKeys.add(key);
         }
 
         // Constant tag should be in neither tagsToAddOrUpdate nor tagsToRemove
@@ -101,18 +88,66 @@ public class TagTestResourceHelper {
             correctTagsInRequests = false;
         }
 
-        // Delete tag should be the single item in tagsToRemove
-        if (tagsToAddOrUpdateKeys.contains("Delete") || !tagsToRemoveKeys.contains("Delete") || tagsToRemoveKeys.size() != 1) {
+        // Only Delete and StackTagKey2 tags should be in tagsToRemove
+        if (tagsToAddOrUpdateKeys.contains("Delete") || tagsToAddOrUpdateKeys.contains("StackTagKey2") ||
+                !tagsToRemoveKeys.contains("Delete") || !tagsToRemoveKeys.contains("StackTagKey2") || tagsToRemoveKeys.size() != 2) {
             correctTagsInRequests = false;
         }
 
-        // Update tag should be in tagsToAddOrUpdate not tagsToRemove
-        if (!tagsToAddOrUpdateKeys.contains("Update") || tagsToRemoveKeys.contains("Update")) {
+        // Update and StackTagKey1 tags (getting updated) should be in tagsToAddOrUpdate and not in tagsToRemove
+        if (!tagsToAddOrUpdateKeys.contains("Update") || !tagsToAddOrUpdateKeys.contains("StackTagKey1") ||
+                tagsToRemoveKeys.contains("Update") || tagsToRemoveKeys.contains("StackTagKey1")) {
             correctTagsInRequests = false;
         }
 
-        // Add tag should be in tagsToAddOrUpdate not tagsToRemove
-        if (!tagsToAddOrUpdateKeys.contains("Add") || tagsToRemoveKeys.contains("Add")) {
+        // Add and StackTagKey4 tags (getting added) should be in tagsToAddOrUpdate and not in tagsToRemove
+        if (!tagsToAddOrUpdateKeys.contains("Add") || !tagsToAddOrUpdateKeys.contains("StackTagKey4") ||
+                tagsToRemoveKeys.contains("Add") || tagsToRemoveKeys.contains("StackTagKey4")) {
+            correctTagsInRequests = false;
+        }
+
+        return correctTagsInRequests;
+    }
+
+    static boolean correctTagsInTagAndUntagRequestsAddTags(Set<Tag> tagsToAddOrUpdate, Set<String> tagsToRemoveKeys) {
+        boolean correctTagsInRequests = true;
+
+        Set<String> tagsToAddOrUpdateKeys = new HashSet<>();
+
+        for (Tag tag : tagsToAddOrUpdate) {
+            tagsToAddOrUpdateKeys.add(tag.key());
+        }
+
+        // Constant, Update, Add, StackTagKey1, StackTagKey4 all should be in tagsToAdd
+        if (!tagsToAddOrUpdateKeys.contains("Constant") || !tagsToAddOrUpdateKeys.contains("Update") ||
+                !tagsToAddOrUpdateKeys.contains("Add") || !tagsToAddOrUpdateKeys.contains("StackTagKey1") ||
+                !tagsToAddOrUpdateKeys.contains("StackTagKey4")) {
+            correctTagsInRequests = false;
+        }
+
+        // tagsToRemove should be empty as we are just adding tags
+        if (!tagsToRemoveKeys.isEmpty()) correctTagsInRequests = false;
+
+        return correctTagsInRequests;
+    }
+
+    static boolean correctTagsInTagAndUntagRequestsRemoveTags(Set<Tag> tagsToAddOrUpdate, Set<String> tagsToRemoveKeys) {
+        boolean correctTagsInRequests = true;
+
+        Set<String> tagsToAddOrUpdateKeys = new HashSet<>();
+
+        for (Tag tag : tagsToAddOrUpdate) {
+            tagsToAddOrUpdateKeys.add(tag.key());
+        }
+
+        // Only Update, Add should be in tagsToAddOrUpdate
+        if (!tagsToAddOrUpdateKeys.contains("Update") || !tagsToAddOrUpdateKeys.contains("Add")) {
+            correctTagsInRequests = false;
+        }
+
+        // Delete, StackTagKey1, and StackTagKey2 should be in tagsToRemove
+        if (!tagsToRemoveKeys.contains("Delete") || !tagsToRemoveKeys.contains("StackTagKey1") ||
+                !tagsToRemoveKeys.contains("StackTagKey2")) {
             correctTagsInRequests = false;
         }
 

--- a/aws-organizations-resourcepolicy/src/test/java/software/amazon/organizations/resourcepolicy/UpdateHandlerTest.java
+++ b/aws-organizations-resourcepolicy/src/test/java/software/amazon/organizations/resourcepolicy/UpdateHandlerTest.java
@@ -126,6 +126,8 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .previousResourceState(initialResourceModel)
             .desiredResourceState(updatedResourceModel)
+            .previousResourceTags(TagTestResourceHelper.defaultStackTags)
+            .desiredResourceTags(TagTestResourceHelper.updatedStackTags)
             .build();
 
         mockReadHandler(true);
@@ -134,19 +136,24 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ProgressEvent<ResourceModel, CallbackContext> response = updateHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
 
-        final Set<Tag> tagsToAddOrUpdate = UpdateHandler.getTagsToAddOrUpdate(
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(initialResourceModel.getTags()),
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(updatedResourceModel.getTags())
+        final Set<Tag> oldTags = TagsHelper.mergeTags(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(initialResourceModel.getTags()),
+                request.getPreviousResourceTags()
         );
 
-        final Set<String> tagKeysToRemove = UpdateHandler.getTagKeysToRemove(
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(initialResourceModel.getTags()),
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(updatedResourceModel.getTags())
+        final Set<Tag> newTags = TagsHelper.mergeTags(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(updatedResourceModel.getTags()),
+                request.getDesiredResourceTags()
         );
+
+        final Set<Tag> tagsToAddOrUpdate = TagsHelper.getTagsToAddOrUpdate(oldTags, newTags);
+        final Set<String> tagKeysToRemove = TagsHelper.getTagKeysToRemove(oldTags, newTags);
 
         verifyHandlerSuccess(response, request);
-        assertThat(TagTestResourceHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourceHelper.updatedTags));
-        assertThat(TagTestResourceHelper.correctTagsInTagAndUntagRequests(tagsToAddOrUpdate, tagKeysToRemove));
+        assertThat(TagTestResourceHelper.tagsEqual(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourceHelper.updatedTags)).isTrue();
+        assertThat(TagTestResourceHelper.correctTagsInTagAndUntagRequests(tagsToAddOrUpdate, tagKeysToRemove)).isTrue();
 
         verify(mockProxyClient.client()).putResourcePolicy(any(PutResourcePolicyRequest.class));
         verifyReadHandler();
@@ -165,6 +172,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .previousResourceState(initialResourceModel)
             .desiredResourceState(updatedResourceModel)
+            .desiredResourceTags(TagTestResourceHelper.updatedStackTags)
             .build();
 
         mockReadHandler(true);
@@ -173,19 +181,24 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ProgressEvent<ResourceModel, CallbackContext> response = updateHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
 
-        final Set<Tag> tagsToAddOrUpdate = UpdateHandler.getTagsToAddOrUpdate(
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(initialResourceModel.getTags()),
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(updatedResourceModel.getTags())
+        final Set<Tag> oldTags = TagsHelper.mergeTags(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(initialResourceModel.getTags()),
+                request.getPreviousResourceTags()
         );
 
-        final Set<String> tagKeysToRemove = UpdateHandler.getTagKeysToRemove(
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(initialResourceModel.getTags()),
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(updatedResourceModel.getTags())
+        final Set<Tag> newTags = TagsHelper.mergeTags(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(updatedResourceModel.getTags()),
+                request.getDesiredResourceTags()
         );
+
+        final Set<Tag> tagsToAddOrUpdate = TagsHelper.getTagsToAddOrUpdate(oldTags, newTags);
+        final Set<String> tagKeysToRemove = TagsHelper.getTagKeysToRemove(oldTags, newTags);
 
         verifyHandlerSuccess(response, request);
-        assertThat(TagTestResourceHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourceHelper.updatedTags));
-        assertThat(TagTestResourceHelper.correctTagsInTagAndUntagRequests(tagsToAddOrUpdate, tagKeysToRemove));
+        assertThat(TagTestResourceHelper.tagsEqual(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourceHelper.updatedTags)).isTrue();
+        assertThat(TagTestResourceHelper.correctTagsInTagAndUntagRequestsAddTags(tagsToAddOrUpdate, tagKeysToRemove)).isTrue();
 
         verify(mockProxyClient.client()).putResourcePolicy(any(PutResourcePolicyRequest.class));
         verifyReadHandler();
@@ -204,6 +217,7 @@ public class UpdateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
             .previousResourceState(initialResourceModel)
             .desiredResourceState(updatedResourceModel)
+            .previousResourceTags(TagTestResourceHelper.defaultStackTags)
             .build();
 
         mockReadHandler(true);
@@ -212,19 +226,24 @@ public class UpdateHandlerTest extends AbstractTestBase {
 
         final ProgressEvent<ResourceModel, CallbackContext> response = updateHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
 
-        final Set<Tag> tagsToAddOrUpdate = UpdateHandler.getTagsToAddOrUpdate(
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(initialResourceModel.getTags()),
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(updatedResourceModel.getTags())
+        final Set<Tag> oldTags = TagsHelper.mergeTags(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(initialResourceModel.getTags()),
+                request.getPreviousResourceTags()
         );
 
-        final Set<String> tagKeysToRemove = UpdateHandler.getTagKeysToRemove(
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(initialResourceModel.getTags()),
-            TagTestResourceHelper.translateResourcePolicyTagsToOrganizationTags(updatedResourceModel.getTags())
+        final Set<Tag> newTags = TagsHelper.mergeTags(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(updatedResourceModel.getTags()),
+                request.getDesiredResourceTags()
         );
+
+        final Set<Tag> tagsToAddOrUpdate = TagsHelper.getTagsToAddOrUpdate(oldTags, newTags);
+        final Set<String> tagKeysToRemove = TagsHelper.getTagKeysToRemove(oldTags, newTags);
 
         verifyHandlerSuccess(response, request);
-        assertThat(TagTestResourceHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourceHelper.updatedTags));
-        assertThat(TagTestResourceHelper.correctTagsInTagAndUntagRequests(tagsToAddOrUpdate, tagKeysToRemove));
+        assertThat(TagTestResourceHelper.tagsEqual(
+                TagsHelper.convertResourcePolicyTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourceHelper.updatedTags)).isTrue();
+        assertThat(TagTestResourceHelper.correctTagsInTagAndUntagRequestsRemoveTags(tagsToAddOrUpdate, tagKeysToRemove)).isTrue();
 
         verify(mockProxyClient.client()).putResourcePolicy(any(PutResourcePolicyRequest.class));
         verifyReadHandler();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Add support to create and update stack tags to ResourcePolicy (RP) CloudFormation stacks by updating the RP create and update handlers.
* Update RP create and update handler tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
