### PR TITLE
Added deduplicate logic when merging stack level and resource level tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ out/
 .settings
 .project
 
+.vscode/
+
 # build and test auto-generated files
 target/
 *.zip

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/TagsHelper.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/TagsHelper.java
@@ -45,7 +45,7 @@ public class TagsHelper {
         return result;
     }
 
-    private static Set<Tag> tagMapToTagSetConverter(final Map<String, String> map) {
+    static Set<Tag> tagMapToTagSetConverter(final Map<String, String> map) {
         return map.entrySet()
                 .stream()
                 .map(entry -> buildTag(entry.getKey(), entry.getValue()))

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/Translator.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/Translator.java
@@ -18,8 +18,8 @@ import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +28,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static software.amazon.organizations.policy.TagsHelper.buildTag;
 
 /**
  * This class is a centralized placeholder for
@@ -97,17 +96,17 @@ public class Translator {
     }
 
     static Collection<Tag> translateTagsForTagResourceRequest(Set<software.amazon.organizations.policy.Tag> tags, Map<String, String> desiredResourceTags) {
-        final Collection<Tag> tagsToReturn = new ArrayList<>();
-
-        if (tags != null) {
-            tags.forEach(tag -> tagsToReturn.add(buildTag(tag.getKey(), tag.getValue())));
-        }
+        Map<String, String> tagsToReturn = new HashMap<>();
 
         if (desiredResourceTags != null) {
-            desiredResourceTags.forEach((key, value) -> tagsToReturn.add(buildTag(key, value)));
+            tagsToReturn.putAll(desiredResourceTags);
         }
 
-        return tagsToReturn;
+        if (tags != null) {
+            tags.forEach(tag -> tagsToReturn.put(tag.getKey(), tag.getValue()));
+        }
+
+        return TagsHelper.tagMapToTagSetConverter(tagsToReturn);
     }
 
     static Set<software.amazon.organizations.policy.Tag> translateTagsFromSdkResponse(List<Tag> inputTags) {

--- a/aws-organizations-resourcepolicy/src/main/java/software/amazon/organizations/resourcepolicy/TagsHelper.java
+++ b/aws-organizations-resourcepolicy/src/main/java/software/amazon/organizations/resourcepolicy/TagsHelper.java
@@ -47,7 +47,7 @@ public class TagsHelper {
         return result;
     }
 
-    private static Set<Tag> tagMapToTagSetConverter(final Map<String, String> map) {
+    static Set<Tag> tagMapToTagSetConverter(final Map<String, String> map) {
         return map.entrySet()
                 .stream()
                 .map(entry -> buildTag(entry.getKey(), entry.getValue()))

--- a/aws-organizations-resourcepolicy/src/main/java/software/amazon/organizations/resourcepolicy/Translator.java
+++ b/aws-organizations-resourcepolicy/src/main/java/software/amazon/organizations/resourcepolicy/Translator.java
@@ -14,8 +14,8 @@ import software.amazon.cloudformation.exceptions.CfnInvalidRequestException;
 import software.amazon.organizations.utils.OrgsLoggerWrapper;
 import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +23,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static software.amazon.organizations.resourcepolicy.TagsHelper.buildTag;
 
 /**
  * This class is a centralized placeholder for
@@ -69,17 +68,19 @@ public class Translator {
     }
 
     static Collection<Tag> translateTagsForTagResourceRequest(Set<software.amazon.organizations.resourcepolicy.Tag> tags, Map<String, String> desiredResourceTags) {
-        final Collection<Tag> tagsToReturn = new ArrayList<>();
+        Map<String, String> tagsToReturn = new HashMap<>();
 
-        if (tags != null) {
-            tags.forEach(tag -> tagsToReturn.add(buildTag(tag.getKey(), tag.getValue())));
-        }
-
+        // Add stack level tags
         if (desiredResourceTags != null) {
-            desiredResourceTags.forEach((key, value) -> tagsToReturn.add(buildTag(key, value)));
+            tagsToReturn.putAll(desiredResourceTags);
         }
 
-        return tagsToReturn;
+        // Add resource level tags
+        if (tags != null) {
+            tags.forEach(tag -> tagsToReturn.put(tag.getKey(), tag.getValue()));
+        }
+
+        return TagsHelper.tagMapToTagSetConverter(tagsToReturn);
     }
 
     static Set<software.amazon.organizations.resourcepolicy.Tag> translateTagsFromSdkResponse(List<Tag> inputTags) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We recently supported the CFN stack level tags, but we didn't add the deduplicate logic when merging the stack and resource level tags, that caused customer requests failure.

In this PR, we updated the `translateTagsForTagResourceRequest` function for resource type `policy` and `resource-policy`, use `Map` data structure to override resource-level tags with stack-level tags if the duplicate keys detected.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
