### PR TITLE
 Implemented nextToken handling in checkIfPolicyExists method while m…

### DIFF
--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
@@ -617,6 +617,53 @@ public class CreateHandlerTest extends AbstractTestBase {
         verifyNoMoreInteractions(mockOrgsClient);
     }
 
+    @Test
+    public void handleRequest_PolicyAlreadyExists_ReturnsAlreadyExistsError_PaginationTest() {
+        final ResourceModel model = generateInitialResourceModel(false, false);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final ListPoliciesResponse firstPageResponse = ListPoliciesResponse.builder()
+                .policies(Arrays.asList(
+                        PolicySummary.builder().id("other-id-1").name("other-name-1").type(TEST_TYPE).build(),
+                        PolicySummary.builder().id("other-id-2").name("other-name-2").type(TEST_TYPE).build()
+                ))
+                .nextToken("nextPageToken")
+                .build();
+
+        final PolicySummary existingPolicy = PolicySummary.builder()
+                .id(TEST_POLICY_ID)
+                .name(TEST_POLICY_NAME)
+                .type(TEST_TYPE)
+                .build();
+
+        final ListPoliciesResponse secondPageResponse = ListPoliciesResponse.builder().policies(Collections.singletonList(existingPolicy)).build();
+        System.out.println("secondPageRespose"+secondPageResponse);
+
+        when(mockProxyClient.client().listPolicies(any(ListPoliciesRequest.class)))
+                .thenReturn(firstPageResponse)
+                .thenReturn(secondPageResponse);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNotNull();
+        assertThat(response.getResourceModel().getId()).isEqualTo(TEST_POLICY_ID);
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(String.format("Policy already exists for policy name [%s].", TEST_POLICY_NAME));
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.AlreadyExists);
+
+        verify(mockProxyClient.client(), times(2)).listPolicies(any(ListPoliciesRequest.class));
+        verify(mockProxyClient.client(), times(0)).createPolicy(any(CreatePolicyRequest.class));
+
+        verify(mockOrgsClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(mockOrgsClient);
+    }
+
     protected CreatePolicyResponse getCreatePolicyResponse() {
         return CreatePolicyResponse.builder().policy(
             Policy.builder()


### PR DESCRIPTION
This PR enhances the `checkIfPolicyExists` method in our AWS Organizations policy handler to support pagination. This improvement allows the method to handle cases where the list of policies spans multiple pages, ensuring a thorough check for existing policies.

## Changes

- Modified `checkIfPolicyExists` method to include `nextToken` in the `ListPoliciesRequest`
- Updated the ProgressEvent builder to include `nextToken` in the response
- Maintained existing functionality for policy existence validation
- Ensured all policies are collected and checked, even across multiple pages

## Why

Previously, our policy existence check was limited to a single page of results. This could potentially miss policies if they weren't in the first page of results returned by the AWS Organizations API. By implementing pagination, we ensure a comprehensive check across all existing policies, improving the reliability and correctness of our resource management.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
