### PR TITLE
Fix policy creation idempotency issue

### DIFF
--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/CreateHandler.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/CreateHandler.java
@@ -20,9 +20,6 @@ import java.util.Optional;
 public class CreateHandler extends BaseHandlerStd {
     private OrgsLoggerWrapper log;
 
-    private static final String ALREADY_EXISTS_ERROR_CODE = "AlreadyExists";
-    private static final String ENTITY_ALREADY_EXISTS_ERROR_CODE = "EntityAlreadyExists";
-
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy awsClientProxy,
         final ResourceHandlerRequest<ResourceModel> request,

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/BaseHandlerStd.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/BaseHandlerStd.java
@@ -43,6 +43,9 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
     private static final int BASE_DELAY = 15; // in seconds
     private static final int MAX_RETRY_ATTEMPT_FOR_RETRIABLE_EXCEPTION = 2;
 
+    protected static final String ALREADY_EXISTS_ERROR_CODE = "AlreadyExists";
+    protected static final String ENTITY_ALREADY_EXISTS_ERROR_CODE = "EntityAlreadyExists";
+
     @Override
     public final ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy proxy,
@@ -130,12 +133,20 @@ public abstract class BaseHandlerStd extends BaseHandler<CallbackContext> {
         final OrgsLoggerWrapper logger,
         final List<String> ignoreErrorCodes
     ) {
+        String errorCode = "";
         if (e instanceof AwsServiceException) {
             final AwsErrorDetails awsErrorDetails = ((AwsServiceException) e).awsErrorDetails();
-            final String errorCode = awsErrorDetails != null ? awsErrorDetails.errorCode() : "";
-            if (ignoreErrorCodes.contains(errorCode)) {
-                return ProgressEvent.progress(resourceModel, callbackContext);
+            if (awsErrorDetails != null) {
+                errorCode = awsErrorDetails.errorCode();
             }
+        }
+        if (e instanceof DuplicatePolicyException) {
+            errorCode = ALREADY_EXISTS_ERROR_CODE;
+        }
+
+        // Swallow AlreadyExists and similar errors on createPolicy call
+        if (ignoreErrorCodes.contains(errorCode)) {
+            return ProgressEvent.progress(resourceModel, callbackContext);
         }
         return handleError(request, e, proxyClient, resourceModel, callbackContext, logger);
     }

--- a/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/CreateHandler.java
+++ b/aws-organizations-policy/src/main/java/software/amazon/organizations/policy/CreateHandler.java
@@ -25,9 +25,6 @@ import java.util.Set;
 public class CreateHandler extends BaseHandlerStd {
     private OrgsLoggerWrapper log;
 
-    private static final String ALREADY_EXISTS_ERROR_CODE = "AlreadyExists";
-    private static final String ENTITY_ALREADY_EXISTS_ERROR_CODE = "EntityAlreadyExists";
-
     public ProgressEvent<ResourceModel, CallbackContext> handleRequest(
         final AmazonWebServicesClientProxy awsClientProxy,
         final ResourceHandlerRequest<ResourceModel> request,

--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/CreateHandlerTest.java
@@ -5,6 +5,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import software.amazon.awssdk.services.organizations.model.AttachPolicyRequest;
 import software.amazon.awssdk.services.organizations.model.AttachPolicyResponse;
@@ -22,6 +24,7 @@ import software.amazon.awssdk.services.organizations.model.ListTargetsForPolicyR
 import software.amazon.awssdk.services.organizations.model.Policy;
 import software.amazon.awssdk.services.organizations.model.PolicySummary;
 import software.amazon.awssdk.services.organizations.model.PolicyTargetSummary;
+import software.amazon.awssdk.services.organizations.model.ServiceException;
 import software.amazon.awssdk.services.organizations.model.TargetNotFoundException;
 
 import software.amazon.cloudformation.proxy.AmazonWebServicesClientProxy;
@@ -42,6 +45,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -651,6 +655,150 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         verify(mockProxyClient.client(), times(2)).listPolicies(any(ListPoliciesRequest.class));
         verify(mockProxyClient.client(), times(0)).createPolicy(any(CreatePolicyRequest.class));
+
+        verify(mockOrgsClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(mockOrgsClient);
+    }
+
+    @Test
+    public void handleRequest_ServiceExceptionOnCreatePolicyCall_ShouldFail() {
+        final ResourceModel model = generateInitialResourceModel(false, false);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        // Simulate createPolicy invocation throwing ServiceException
+        final String SERVICE_EXCEPTION_MESSAGE = "Test service exception message";
+        when(mockProxyClient.client().createPolicy(any(CreatePolicyRequest.class)))
+                .thenThrow(ServiceException.builder()
+                        .message(SERVICE_EXCEPTION_MESSAGE)
+                        .build());
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNotNull();
+        assertThat(response.getResourceModel().getId()).isNull();
+        assertThat(response.getResourceModel().getName()).isEqualTo(model.getName());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isEqualTo(SERVICE_EXCEPTION_MESSAGE);
+        assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.ServiceInternalError);
+
+        verify(mockProxyClient.client()).listPolicies(any(ListPoliciesRequest.class));
+        verify(mockProxyClient.client()).createPolicy(any(CreatePolicyRequest.class));
+
+        // Since handleError is invoked, verify that calls in attachPolicyToTargets or ReadHandler handleRequest are never invoked
+        verify(mockProxyClient.client(), never()).attachPolicy(any(AttachPolicyRequest.class));
+        verify(mockProxyClient.client(), never()).describePolicy(any(DescribePolicyRequest.class));
+        verify(mockProxyClient.client(), never()).listTargetsForPolicy(any(ListTargetsForPolicyRequest.class));
+        verify(mockProxyClient.client(), never()).listTagsForResource(any(ListTagsForResourceRequest.class));
+
+        verify(mockOrgsClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(mockOrgsClient);
+    }
+
+    @Test
+    public void handleRequest_ReInvokedAfterPreCheckPasses_PolicyAlreadyCreated_ShouldSwallowErrorAndSucceed() {
+        final ResourceModel model = generateInitialResourceModel(false, false);
+
+        // Simulate the first invocation being complete by setting PreExistenceCheckComplete true
+        CallbackContext context = new CallbackContext();
+        context.setPreExistenceCheckComplete(true);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        // Simulate first invocation already successfully created policy, giving AlreadyExists error on second createPolicy invocation
+        when(mockProxyClient.client().createPolicy(any(CreatePolicyRequest.class)))
+                .thenThrow(AwsServiceException.builder()
+                        .awsErrorDetails(AwsErrorDetails.builder().errorCode("AlreadyExists").build())
+                        .build());
+
+        final DescribePolicyResponse describePolicyResponse = getDescribePolicyResponse();
+        when(mockProxyClient.client().describePolicy(any(DescribePolicyRequest.class))).thenReturn(describePolicyResponse);
+
+        final ListTargetsForPolicyResponse listTargetsResponse = ListTargetsForPolicyResponse.builder()
+                .nextToken(null)
+                .build();
+        when(mockProxyClient.client().listTargetsForPolicy(any(ListTargetsForPolicyRequest.class))).thenReturn(listTargetsResponse);
+
+        final ListTagsForResourceResponse listTagsResponse = TagTestResourceHelper.buildEmptyTagsResponse();
+        when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsResponse);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, context, mockProxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNotNull();
+        assertThat(response.getResourceModel().getId()).isEqualTo(TEST_POLICY_ID);
+        assertThat(response.getResourceModel().getName()).isEqualTo(model.getName());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        // Verify checkIfPolicyExists is not reached since PreExistenceCheck is already complete
+        verify(mockProxyClient.client(), never()).listPolicies(any(ListPoliciesRequest.class));
+
+        verify(mockProxyClient.client()).createPolicy(any(CreatePolicyRequest.class));
+        verify(mockProxyClient.client()).describePolicy(any(DescribePolicyRequest.class));
+        verify(mockProxyClient.client()).listTargetsForPolicy(any(ListTargetsForPolicyRequest.class));
+        verify(mockProxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
+
+        verify(mockOrgsClient, atLeastOnce()).serviceName();
+        verifyNoMoreInteractions(mockOrgsClient);
+    }
+
+    @Test
+    public void handleRequest_ReInvokedAfterPreCheckPasses_PolicyNotPresent_ShouldSucceed() {
+        final ResourceModel model = generateInitialResourceModel(false, false);
+
+        // Simulate the first invocation being complete by setting PreExistenceCheckComplete true
+        CallbackContext context = new CallbackContext();
+        context.setPreExistenceCheckComplete(true);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .desiredResourceState(model)
+                .build();
+
+        final CreatePolicyResponse createPolicyResponse = getCreatePolicyResponse();
+        when(mockProxyClient.client().createPolicy(any(CreatePolicyRequest.class)))
+                .thenReturn(createPolicyResponse);
+
+        final DescribePolicyResponse describePolicyResponse = getDescribePolicyResponse();
+        when(mockProxyClient.client().describePolicy(any(DescribePolicyRequest.class))).thenReturn(describePolicyResponse);
+
+        final ListTargetsForPolicyResponse listTargetsResponse = ListTargetsForPolicyResponse.builder()
+                .nextToken(null)
+                .build();
+        when(mockProxyClient.client().listTargetsForPolicy(any(ListTargetsForPolicyRequest.class))).thenReturn(listTargetsResponse);
+
+        final ListTagsForResourceResponse listTagsResponse = TagTestResourceHelper.buildEmptyTagsResponse();
+        when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsResponse);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, context, mockProxyClient, logger);
+
+        assertThat(response).isNotNull();
+        assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
+        assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
+        assertThat(response.getResourceModel()).isNotNull();
+        assertThat(response.getResourceModel().getId()).isEqualTo(TEST_POLICY_ID);
+        assertThat(response.getResourceModel().getName()).isEqualTo(model.getName());
+        assertThat(response.getResourceModels()).isNull();
+        assertThat(response.getMessage()).isNull();
+        assertThat(response.getErrorCode()).isNull();
+
+        // Verify checkIfPolicyExists is not reached since PreExistenceCheck is already complete
+        verify(mockProxyClient.client(), never()).listPolicies(any(ListPoliciesRequest.class));
+
+        verify(mockProxyClient.client()).createPolicy(any(CreatePolicyRequest.class));
+        verify(mockProxyClient.client()).describePolicy(any(DescribePolicyRequest.class));
+        verify(mockProxyClient.client()).listTargetsForPolicy(any(ListTargetsForPolicyRequest.class));
+        verify(mockProxyClient.client()).listTagsForResource(any(ListTagsForResourceRequest.class));
 
         verify(mockOrgsClient, atLeastOnce()).serviceName();
         verifyNoMoreInteractions(mockOrgsClient);


### PR DESCRIPTION
*Description of changes:*

Fixing idempotency issue while policy creation, performing some exception translations:
* Check if policy exists only if `PreExistenceCheck` fails
* Swallow `AlreadyExists` error on an invocation where previous invocation already created policy
* Translating `DuplicatePolicyException` in `handleErrorOnCreate` to catch `AlreadyExists` error code on Policy create call
* Also translating `DuplicateOrganizationalUnitException` in `handleErrorOnCreate` to catch `AlreadyExists` error code on OU create call
* Added corresponding unit tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
