### PR TITLE
Adding callbackDelay to fix policy creation idempotency issue, update unit tests

### DIFF
--- a/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
+++ b/aws-organizations-policy/src/test/java/software/amazon/organizations/policy/AbstractTestBase.java
@@ -51,6 +51,8 @@ public class AbstractTestBase {
     protected static final String TEST_NEXT_TOKEN = "mockNextTokenItem";
     protected static final String POLICY_SCHEMA_SHA256_HEXSTRING = "4F8BADE6D11D6984EECB9B8561FCD73697E744E1A2AD44F069D73D08C495962B";
     protected static final String POLICY_JSON_SCHEMA_FILE_NAME = "aws-organizations-policy.json";
+    protected static final int CALLBACK_DELAY = 1;
+    protected static final int MAX_RETRY_ATTEMPT = 2;
 
     protected static final Credentials MOCK_CREDENTIALS;
     protected static final LoggerProxy loggerProxy;


### PR DESCRIPTION
*Description of changes:*
* Adding `callbackDelay` of 1 second to the `IN_PROGRESS` progress event once policy is not found. This is primarily to pass on the context flags like `PreExistenceCheckComplete` onto the next call.
* Adding similar delay once create policy is done to avoid `InvalidInputException` on `describePolicy` call later.
* In `checkIfPolicyExists`, exit out of the do-while early when policy already found to cut down time and number of `ListPolicy` calls.
* Update corresponding unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
