### PR TITLE
Adding callbackDelay to fix ou creation idempotency issue, update unit tests

### DIFF
--- a/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/CallbackContext.java
+++ b/aws-organizations-organizationalunit/src/main/java/software/amazon/organizations/organizationalunit/CallbackContext.java
@@ -21,4 +21,5 @@ public class CallbackContext extends StdCallbackContext {
     }
     private boolean isPreExistenceCheckComplete = false;
     private boolean didResourceAlreadyExist = false;
+    private boolean isOuCreated = false;
 }

--- a/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/AbstractTestBase.java
+++ b/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/AbstractTestBase.java
@@ -25,6 +25,7 @@ public class AbstractTestBase {
     protected static final String TEST_PARENT_ID = "r-hhhu";
     protected static final String OU_JSON_SCHEMA_FILE_NAME = "aws-organizations-organizationalunit.json";
     protected static final String OU_SCHEMA_SHA256_HEXSTRING = "CD9565D9E0859B36109E6106F61BFA9781C0366DD054511D31F30765FEC1933E";
+    protected static final int CALLBACK_DELAY = 1;
 
     protected static final Credentials MOCK_CREDENTIALS;
     protected static final LoggerProxy loggerProxy;

--- a/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/CreateHandlerTest.java
+++ b/aws-organizations-organizationalunit/src/test/java/software/amazon/organizations/organizationalunit/CreateHandlerTest.java
@@ -4,8 +4,6 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.HashSet;
 
-import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
-import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import software.amazon.awssdk.services.organizations.model.DescribeOrganizationalUnitRequest;
 import software.amazon.awssdk.services.organizations.model.DescribeOrganizationalUnitResponse;
@@ -93,7 +91,16 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(mockProxyClient.client().listParents(any(ListParentsRequest.class))).thenReturn(listParentsResponse);
         when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsForResourceResponse);
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = null;
+        do {
+            final CallbackContext callbackContext = (response == null) ? new CallbackContext() : response.getCallbackContext();
+            response = createHandler.handleRequest(mockAwsClientProxy, request, callbackContext, mockProxyClient, logger);
+
+            if (response.getStatus().equals(OperationStatus.IN_PROGRESS)) {
+                assertThat(response.getCallbackDelaySeconds()).isEqualTo(CALLBACK_DELAY);
+            }
+
+        } while (response.getStatus().equals(OperationStatus.IN_PROGRESS));
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -139,7 +146,16 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(mockProxyClient.client().listParents(any(ListParentsRequest.class))).thenReturn(listParentsResponse);
         when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsForResourceResponse);
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = null;
+        do {
+            final CallbackContext callbackContext = (response == null) ? new CallbackContext() : response.getCallbackContext();
+            response = createHandler.handleRequest(mockAwsClientProxy, request, callbackContext, mockProxyClient, logger);
+
+            if (response.getStatus().equals(OperationStatus.IN_PROGRESS)) {
+                assertThat(response.getCallbackDelaySeconds()).isEqualTo(CALLBACK_DELAY);
+            }
+
+        } while (response.getStatus().equals(OperationStatus.IN_PROGRESS));
 
         assertThat(response.getResourceModel().getTags()).isEqualTo(new HashSet<Tag>());
 
@@ -241,7 +257,16 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(mockProxyClient.client().listParents(any(ListParentsRequest.class))).thenReturn(listParentsResponse);
         when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsForResourceResponse);
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = null;
+        do {
+            final CallbackContext callbackContext = (response == null) ? new CallbackContext() : response.getCallbackContext();
+            response = createHandler.handleRequest(mockAwsClientProxy, request, callbackContext, mockProxyClient, logger);
+
+            if (response.getStatus().equals(OperationStatus.IN_PROGRESS)) {
+                assertThat(response.getCallbackDelaySeconds()).isEqualTo(CALLBACK_DELAY);
+            }
+
+        } while (response.getStatus().equals(OperationStatus.IN_PROGRESS));
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);
@@ -273,7 +298,7 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .organizationalUnits(Collections.singletonList(
                         OrganizationalUnit.builder()
                                 .id("TestOU")
-                                .name(model.getName())
+                                .name("TestName")
                                 .build()
                 ))
                 .nextToken("nextPageToken")
@@ -292,7 +317,16 @@ public class CreateHandlerTest extends AbstractTestBase {
                 .thenReturn(listOUResponseFirst)
                 .thenReturn(listOUResponseSecond);
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = null;
+        do {
+            final CallbackContext callbackContext = (response == null) ? new CallbackContext() : response.getCallbackContext();
+            response = createHandler.handleRequest(mockAwsClientProxy, request, callbackContext, mockProxyClient, logger);
+
+            if (response.getStatus().equals(OperationStatus.IN_PROGRESS)) {
+                assertThat(response.getCallbackDelaySeconds()).isEqualTo(CALLBACK_DELAY);
+            }
+
+        } while (response.getStatus().equals(OperationStatus.IN_PROGRESS));
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
@@ -326,7 +360,16 @@ public class CreateHandlerTest extends AbstractTestBase {
                         .message(TEST_EXCEPTION_MESSAGE)
                         .build());
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = null;
+        do {
+            final CallbackContext callbackContext = (response == null) ? new CallbackContext() : response.getCallbackContext();
+            response = createHandler.handleRequest(mockAwsClientProxy, request, callbackContext, mockProxyClient, logger);
+
+            if (response.getStatus().equals(OperationStatus.IN_PROGRESS)) {
+                assertThat(response.getCallbackDelaySeconds()).isEqualTo(CALLBACK_DELAY);
+            }
+
+        } while (response.getStatus().equals(OperationStatus.IN_PROGRESS));
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
@@ -420,7 +463,16 @@ public class CreateHandlerTest extends AbstractTestBase {
         when(mockProxyClient.client().listParents(any(ListParentsRequest.class))).thenReturn(listParentsResponse);
         when(mockProxyClient.client().listTagsForResource(any(ListTagsForResourceRequest.class))).thenReturn(listTagsForResourceResponse);
 
-        final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, context, mockProxyClient, logger);
+        ProgressEvent<ResourceModel, CallbackContext> response = null;
+        do {
+            final CallbackContext callbackContext = (response == null) ? context : response.getCallbackContext();
+            response = createHandler.handleRequest(mockAwsClientProxy, request, callbackContext, mockProxyClient, logger);
+
+            if (response.getStatus().equals(OperationStatus.IN_PROGRESS)) {
+                assertThat(response.getCallbackDelaySeconds()).isEqualTo(CALLBACK_DELAY);
+            }
+
+        } while (response.getStatus().equals(OperationStatus.IN_PROGRESS));
 
         assertThat(response).isNotNull();
         assertThat(response.getStatus()).isEqualTo(OperationStatus.SUCCESS);


### PR DESCRIPTION
*Description of changes:*
* Adding new attribute in callback context `isOuCreated` and maintain through callbacks to make early exits.
* Adding `callbackDelay` of 1 second to the `IN_PROGRESS` progress event once ou is not found. This is primarily to pass on the context flags like `PreExistenceCheckComplete` onto the next call.
* Adding similar delay once create ou is done to avoid `InvalidInputException` on `describeOrganizationalUnit` call later in read handler.
* In `checkIfOrganizationalUnitExists`, exit out of the do-while early when ou already found, to cut down time and number of `ListOrganizationalUnitsForParent` calls.
* Update corresponding unit tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.