### PR TITLE
Adding source and destination empty check in update account handler

### DIFF
--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/UpdateHandler.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/UpdateHandler.java
@@ -2,6 +2,7 @@ package software.amazon.organizations.account;
 
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.collections4.CollectionUtils;
 import software.amazon.awssdk.services.organizations.OrganizationsClient;
 import software.amazon.awssdk.services.organizations.model.DuplicateAccountException;
 import software.amazon.awssdk.services.organizations.model.InvalidInputException;
@@ -72,6 +73,9 @@ public class UpdateHandler extends BaseHandlerStd {
         Set<String> parentIds = model.getParentIds();
         String accountId = model.getAccountId();
         String rootID = null;
+
+        previousParentIds = CollectionUtils.isEmpty(previousParentIds) ? null : previousParentIds;
+        parentIds = CollectionUtils.isEmpty(parentIds) ? null : parentIds;
 
         if (previousParentIds != null ^ parentIds != null) {
             logger.log(String.format("%s is missing a parentId for account [%s]. Retrieving root as parent", previousParentIds == null ? "Previous model" : "New model", accountId));

--- a/aws-organizations-account/src/test/java/software/amazon/organizations/account/AbstractTestBase.java
+++ b/aws-organizations-account/src/test/java/software/amazon/organizations/account/AbstractTestBase.java
@@ -35,6 +35,7 @@ public class AbstractTestBase {
     protected static final Set<String> TEST_PARENT_IDS = ImmutableSet.of(TEST_DESTINATION_PARENT_ID);
     protected static final Set<String> TEST_PARENT_UPDATED_IDS = ImmutableSet.of(TEST_DESTINATION_UPDATED_PARENT_ID);
     protected static final Set<String> TEST_MULTIPLE_PARENT_IDS = ImmutableSet.of(TEST_SOURCE_PARENT_ID, TEST_DESTINATION_PARENT_ID);
+    protected static final Set<String> TEST_EMPTY_PARENT_IDS = ImmutableSet.of();
     protected static final String EMAIL_ALREADY_EXISTS = "EMAIL_ALREADY_EXISTS";
     protected static final String ACCOUNT_LIMIT_EXCEEDED = "ACCOUNT_LIMIT_EXCEEDED";
     protected static final String INVALID_EMAIL = "INVALID_EMAIL";

--- a/aws-organizations-account/src/test/java/software/amazon/organizations/account/UpdateHandlerTest.java
+++ b/aws-organizations-account/src/test/java/software/amazon/organizations/account/UpdateHandlerTest.java
@@ -235,6 +235,97 @@ public class UpdateHandlerTest extends AbstractTestBase {
     }
 
     @Test
+    public void handleRequest_SourceAndDestinationEmpty_Success() {
+        final ResourceModel previousResourceModel = generatePreviousResourceModel(null).toBuilder()
+                .parentIds(TEST_EMPTY_PARENT_IDS)
+                .build();
+        final ResourceModel model = generateUpdatedResourceModel(null).toBuilder()
+                .parentIds(TEST_EMPTY_PARENT_IDS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(previousResourceModel)
+                .desiredResourceState(model)
+                .build();
+
+        // Read Handler Mocks
+        whenReadMockSetup(request, null);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response =
+                updateHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+
+        // Verify Response
+        verifyHandlerSuccess(response, request);
+        verifyReadHandler();
+
+        // Verify account was not moved
+        verify(mockProxyClient.client(), never()).listRoots(any(ListRootsRequest.class));
+        verify(mockProxyClient.client(), never()).moveAccount(any(MoveAccountRequest.class));
+
+        tearDown();
+    }
+
+    @Test
+    public void handleRequest_SourceTargetEmpty_Success() {
+        final ResourceModel previousResourceModel = generatePreviousResourceModel(null).toBuilder()
+                .parentIds(TEST_EMPTY_PARENT_IDS)
+                .build();
+        final ResourceModel model = generateUpdatedResourceModel(null);
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(previousResourceModel)
+                .desiredResourceState(model)
+                .build();
+
+        ListRootsResponse listRootsResponse = getListRootsResponse();
+        MoveAccountResponse moveAccountResponse = getMoveAccountResponse();
+
+        when(mockProxyClient.client().listRoots(any(ListRootsRequest.class))).thenReturn(listRootsResponse);
+        when(mockProxyClient.client().moveAccount(any(MoveAccountRequest.class))).thenReturn(moveAccountResponse);
+        whenReadMockSetup(request, null);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response =
+                updateHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+
+        // Verify Response
+        verifyHandlerSuccess(response, request);
+        verify(mockProxyClient.client()).moveAccount(any(MoveAccountRequest.class));
+        verify(mockProxyClient.client()).listRoots(any(ListRootsRequest.class));
+
+        tearDown();
+    }
+
+    @Test
+    public void handleRequest_DestinationTargetEmpty_Success() {
+        final ResourceModel previousResourceModel = generatePreviousResourceModel(null);
+        final ResourceModel model = generateUpdatedResourceModel(null).toBuilder()
+                .parentIds(TEST_EMPTY_PARENT_IDS)
+                .build();
+
+        final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
+                .previousResourceState(previousResourceModel)
+                .desiredResourceState(model)
+                .build();
+
+        ListRootsResponse listRootsResponse = getListRootsResponse();
+        MoveAccountResponse moveAccountResponse = getMoveAccountResponse();
+
+        when(mockProxyClient.client().listRoots(any(ListRootsRequest.class))).thenReturn(listRootsResponse);
+        when(mockProxyClient.client().moveAccount(any(MoveAccountRequest.class))).thenReturn(moveAccountResponse);
+        whenReadMockSetup(request, null);
+
+        final ProgressEvent<ResourceModel, CallbackContext> response =
+                updateHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
+
+        // Verify Response
+        verifyHandlerSuccess(response, request);
+        verify(mockProxyClient.client()).moveAccount(any(MoveAccountRequest.class));
+        verify(mockProxyClient.client()).listRoots(any(ListRootsRequest.class));
+
+        tearDown();
+    }
+
+    @Test
     public void handleRequest_MoveAccountThrowsDuplicateAccountException_Success() {
         final ResourceModel previousResourceModel = generatePreviousResourceModel(null);
         final ResourceModel model = generateUpdatedResourceModel(null);


### PR DESCRIPTION
*Description of changes:*

- Adding empty check for source and destination account Ids in update account handler. This prevents an error from being thrown when an empty set ("[]") is inputted to the "ParentIds" field in the CloudFormation template. 

*Testing:*

- Unit and integration tests
- Manual testing in AWS console with personal development account

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
