### PR TITLE
Updating Account create and update handlers to support stack tags

### DIFF
--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/CreateHandler.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/CreateHandler.java
@@ -62,7 +62,7 @@ public class CreateHandler extends BaseHandlerStd {
                         return ProgressEvent.progress(model, callbackContext);
                     }
                     return awsClientProxy.initiate("AWS-Organizations-Account::CreateAccount", orgsClient, progress.getResourceModel(), progress.getCallbackContext())
-                            .translateToServiceRequest(Translator::translateToCreateAccountRequest)
+                            .translateToServiceRequest(x -> Translator.translateToCreateAccountRequest(x, request))
                             .makeServiceCall(this::createAccount)
                             .handleError((organizationsRequest, e, proxyClient1, model1, context) -> handleError(organizationsRequest, request, e, proxyClient1, model1, context, logger))
                             .done(CreateAccountResponse -> {

--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/TagsHelper.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/TagsHelper.java
@@ -1,0 +1,61 @@
+package software.amazon.organizations.account;
+
+import com.google.common.collect.Sets;
+import software.amazon.awssdk.services.organizations.model.Tag;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class TagsHelper {
+
+    static Set<Tag> convertAccountTagToOrganizationTag(final Set<software.amazon.organizations.account.Tag> tags) {
+        final Set<Tag> tagsToReturn = new HashSet<>();
+        if (tags != null) {
+            for (software.amazon.organizations.account.Tag inputTag : tags) {
+                Tag tag = buildTag(inputTag.getKey(), inputTag.getValue());
+                tagsToReturn.add(tag);
+            }
+        }
+        return tagsToReturn;
+    }
+
+    static Set<String> getTagKeysToRemove(
+            Set<Tag> existingTags, Set<Tag> requestedTags) {
+        final Set<String> existingTagKeys = getTagKeySet(existingTags);
+        final Set<String> requestedTagKeys = getTagKeySet(requestedTags);
+        return Sets.difference(existingTagKeys, requestedTagKeys);
+    }
+
+    private static Set<String> getTagKeySet(Set<Tag> existingTags) {
+        return existingTags.stream().map(Tag::key).collect(Collectors.toSet());
+    }
+
+    static Set<Tag> getTagsToAddOrUpdate(
+            Set<Tag> existingTags, Set<Tag> requestedTags) {
+        return Sets.difference(requestedTags, existingTags);
+    }
+
+    static Set<Tag> mergeTags(final Set<Tag> resourceTags, final Map<String, String> desiredResourceTags) {
+        final Set<Tag> result = (resourceTags == null) ? new HashSet<>() : new HashSet<>(resourceTags);
+        if (desiredResourceTags != null) {
+            result.addAll(tagMapToTagSetConverter(desiredResourceTags));
+        }
+        return result;
+    }
+
+    private static Set<Tag> tagMapToTagSetConverter(final Map<String, String> map) {
+        return map.entrySet()
+                .stream()
+                .map(entry -> buildTag(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toSet());
+    }
+
+    static Tag buildTag(String key, String value) {
+        return Tag.builder()
+                .key(key)
+                .value(value)
+                .build();
+    }
+}

--- a/aws-organizations-account/src/main/java/software/amazon/organizations/account/Translator.java
+++ b/aws-organizations-account/src/main/java/software/amazon/organizations/account/Translator.java
@@ -16,15 +16,19 @@ import software.amazon.awssdk.services.organizations.model.MoveAccountRequest;
 import software.amazon.awssdk.services.organizations.model.Tag;
 import software.amazon.awssdk.services.organizations.model.TagResourceRequest;
 import software.amazon.awssdk.services.organizations.model.UntagResourceRequest;
+import software.amazon.cloudformation.proxy.ResourceHandlerRequest;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static software.amazon.organizations.account.TagsHelper.buildTag;
 
 /**
  * This class is a centralized placeholder for
@@ -80,12 +84,12 @@ public class Translator {
                    .build();
     }
 
-    static CreateAccountRequest translateToCreateAccountRequest(final ResourceModel model) {
+    static CreateAccountRequest translateToCreateAccountRequest(final ResourceModel model, final ResourceHandlerRequest<ResourceModel> request) {
         return CreateAccountRequest.builder()
                    .accountName(model.getAccountName())
                    .email(model.getEmail())
                    .roleName(model.getRoleName())
-                   .tags(translateTagsForTagResourceRequest(model.getTags()))
+                   .tags(translateTagsForTagResourceRequest(model.getTags(), request.getDesiredResourceTags()))
                    .build();
     }
 
@@ -125,16 +129,23 @@ public class Translator {
                    .build();
     }
 
-    static Collection<software.amazon.awssdk.services.organizations.model.Tag> translateTagsForTagResourceRequest(Set<software.amazon.organizations.account.Tag> tags) {
-        if (tags == null) return new ArrayList<>();
-        final Collection<software.amazon.awssdk.services.organizations.model.Tag> tagsToReturn = new ArrayList<>();
-        for (software.amazon.organizations.account.Tag inputTags : tags) {
-            software.amazon.awssdk.services.organizations.model.Tag tag = Tag.builder()
-                                                                              .key(inputTags.getKey())
-                                                                              .value(inputTags.getValue())
-                                                                              .build();
-            tagsToReturn.add(tag);
+    static Collection<Tag> translateTagsForTagResourceRequest(Set<software.amazon.organizations.account.Tag> tags, Map<String, String> desiredResourceTags) {
+        final Collection<Tag> tagsToReturn = new ArrayList<>();
+
+        if (tags != null) {
+            for (software.amazon.organizations.account.Tag inputTags : tags) {
+                Tag tag = buildTag(inputTags.getKey(), inputTags.getValue());
+                tagsToReturn.add(tag);
+            }
         }
+
+        if (desiredResourceTags != null) {
+            for (Map.Entry<String, String> resourceTag : desiredResourceTags.entrySet()) {
+                Tag tag = buildTag(resourceTag.getKey(), resourceTag.getValue());
+                tagsToReturn.add(tag);
+            }
+        }
+
         return tagsToReturn;
     }
 

--- a/aws-organizations-account/src/test/java/software/amazon/organizations/account/CreateHandlerTest.java
+++ b/aws-organizations-account/src/test/java/software/amazon/organizations/account/CreateHandlerTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static software.amazon.organizations.account.TagTestResourcesHelper.defaultStackTags;
 
 @ExtendWith(MockitoExtension.class)
 public class CreateHandlerTest extends AbstractTestBase {
@@ -68,6 +69,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -95,7 +97,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
         assertThat(response.getResourceModel().getParentIds()).isEqualTo(TEST_PARENT_IDS);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
@@ -113,6 +117,7 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .awsPartition(GOV_CLOUD_PARTITION)
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), loggerProxy);
@@ -126,7 +131,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
         assertThat(response.getResourceModel().getParentIds()).isEqualTo(TEST_PARENT_IDS);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
 
         verify(mockProxyClient.client(), times(0)).createAccount(any(CreateAccountRequest.class));
         verify(mockProxyClient.client(), times(0)).describeCreateAccountStatus(any(DescribeCreateAccountStatusRequest.class));
@@ -139,6 +146,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -161,7 +169,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
         assertThat(response.getResourceModel().getParentIds()).isEqualTo(TEST_PARENT_IDS);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
 
         verify(mockProxyClient.client()).listAccounts(any(ListAccountsRequest.class));
         verify(mockProxyClient.client(), times(0)).createAccount(any(CreateAccountRequest.class));
@@ -176,6 +186,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
@@ -187,7 +198,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getAccountId()).isNull();
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.InvalidRequest);
 
         verify(mockProxyClient.client(), times(0)).createAccount(any(CreateAccountRequest.class));
@@ -201,6 +214,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -229,7 +243,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
         assertThat(response.getResourceModel().getParentIds()).isEqualTo(TEST_PARENT_IDS);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
 
         verify(mockProxyClient.client()).listAccounts(any(ListAccountsRequest.class));
         verify(mockProxyClient.client()).createAccount(any(CreateAccountRequest.class));
@@ -243,6 +259,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ListAccountsResponse emptyListAccountsResponse = ListAccountsResponse.builder()
@@ -296,6 +313,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -321,7 +339,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
         assertThat(response.getResourceModel().getParentIds()).isEqualTo(TEST_PARENT_IDS);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
 
         verify(mockProxyClient.client()).listAccounts(any(ListAccountsRequest.class));
         verify(mockProxyClient.client()).createAccount(any(CreateAccountRequest.class));
@@ -335,6 +355,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -360,7 +381,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
         assertThat(response.getResourceModel().getParentIds()).isEqualTo(TEST_PARENT_IDS);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
 
         verify(mockProxyClient.client()).listAccounts(any(ListAccountsRequest.class));
         verify(mockProxyClient.client()).createAccount(any(CreateAccountRequest.class));
@@ -373,8 +396,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         final ResourceModel model = generateCreateResourceModel();
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
-                .desiredResourceState(model)
-                .build();
+                                                                  .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
+                                                                  .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
                 .accounts(Collections.emptyList())
@@ -383,8 +407,8 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final CreateAccountResponse createAccountResponse = getCreateAccountResponse();
         final DescribeCreateAccountStatusResponse describeCreateAccountStatusResponse = DescribeCreateAccountStatusResponse.builder()
-                .createAccountStatus(CreateAccountStatusFailedWithUnknownFailure)
-                .build();
+                                                                                            .createAccountStatus(CreateAccountStatusFailedWithUnknownFailure)
+                                                                                            .build();
 
         when(mockProxyClient.client().createAccount(any(CreateAccountRequest.class))).thenReturn(createAccountResponse);
         when(mockProxyClient.client().describeCreateAccountStatus(any(DescribeCreateAccountStatusRequest.class))).thenReturn(describeCreateAccountStatusResponse);
@@ -399,7 +423,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
         assertThat(response.getResourceModel().getParentIds()).isEqualTo(TEST_PARENT_IDS);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
 
         verify(mockProxyClient.client()).listAccounts(any(ListAccountsRequest.class));
         verify(mockProxyClient.client()).createAccount(any(CreateAccountRequest.class));
@@ -413,6 +439,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
+                .desiredResourceTags(defaultStackTags)
                 .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -438,7 +465,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
         assertThat(response.getResourceModel().getParentIds()).isEqualTo(TEST_PARENT_IDS);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
 
         verify(mockProxyClient.client()).listAccounts(any(ListAccountsRequest.class));
         verify(mockProxyClient.client()).createAccount(any(CreateAccountRequest.class));
@@ -452,6 +481,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ProgressEvent<ResourceModel, CallbackContext> response = createHandler.handleRequest(mockAwsClientProxy, request, new CallbackContext(), mockProxyClient, logger);
@@ -465,7 +495,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getEmail()).isNull();
         assertThat(response.getResourceModel().getAccountName()).isNull();
         assertThat(response.getResourceModel().getParentIds()).isEqualTo(TEST_PARENT_IDS);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
 
         verify(mockProxyClient.client(), times(0)).createAccount(any(CreateAccountRequest.class));
         verify(mockProxyClient.client(), atLeast(0)).describeCreateAccountStatus(any(DescribeCreateAccountStatusRequest.class));
@@ -478,6 +510,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -501,7 +534,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getAccountId()).isEqualTo(TEST_ACCOUNT_ID);
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
@@ -518,6 +553,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -544,7 +580,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getAccountId()).isEqualTo(TEST_ACCOUNT_ID);
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
 
         verify(mockProxyClient.client()).listAccounts(any(ListAccountsRequest.class));
         verify(mockProxyClient.client()).createAccount(any(CreateAccountRequest.class));
@@ -558,6 +596,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                                                                   .desiredResourceState(model)
+                                                                  .desiredResourceTags(defaultStackTags)
                                                                   .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -580,7 +619,9 @@ public class CreateHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getAccountId()).isNull();
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getAccountName()).isEqualTo(TEST_ACCOUNT_NAME);
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
 
         verify(mockProxyClient.client()).listAccounts(any(ListAccountsRequest.class));
         verify(mockProxyClient.client()).createAccount(any(CreateAccountRequest.class));
@@ -597,6 +638,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
+                .desiredResourceTags(defaultStackTags)
                 .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -632,6 +674,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
+                .desiredResourceTags(defaultStackTags)
                 .build();
 
         final ListAccountsResponse listAccountsResponse = ListAccountsResponse.builder()
@@ -668,6 +711,7 @@ public class CreateHandlerTest extends AbstractTestBase {
 
         final ResourceHandlerRequest<ResourceModel> request = ResourceHandlerRequest.<ResourceModel>builder()
                 .desiredResourceState(model)
+                .desiredResourceTags(defaultStackTags)
                 .build();
 
         final ListAccountsResponse firstListAccountsResponse = ListAccountsResponse.builder()

--- a/aws-organizations-account/src/test/java/software/amazon/organizations/account/ReadHandlerTest.java
+++ b/aws-organizations-account/src/test/java/software/amazon/organizations/account/ReadHandlerTest.java
@@ -93,7 +93,9 @@ public class ReadHandlerTest extends AbstractTestBase {
         assertThat(response.getResourceModel().getJoinedTimestamp()).isEqualTo(TEST_JOINED_TIMESTAMP.toString());
         assertThat(response.getResourceModel().getEmail()).isEqualTo(TEST_ACCOUNT_EMAIL);
         assertThat(response.getResourceModel().getParentIds()).isEqualTo(ImmutableSet.of(TEST_DESTINATION_PARENT_ID));
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
+        assertThat(TagTestResourcesHelper.tagsEqual(
+                TagsHelper.convertAccountTagToOrganizationTag(response.getResourceModel().getTags()),
+                TagTestResourcesHelper.defaultTags)).isTrue();
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getMessage()).isNull();
         assertThat(response.getErrorCode()).isNull();
@@ -144,7 +146,6 @@ public class ReadHandlerTest extends AbstractTestBase {
         assertThat(response.getStatus()).isEqualTo(OperationStatus.FAILED);
         assertThat(response.getCallbackDelaySeconds()).isEqualTo(0);
         assertThat(response.getResourceModel()).isNotNull();
-        assertThat(TagTestResourcesHelper.tagsEqual(response.getResourceModel().getTags(), TagTestResourcesHelper.defaultTags));
         assertThat(response.getResourceModels()).isNull();
         assertThat(response.getErrorCode()).isEqualTo(HandlerErrorCode.NotFound);
 

--- a/aws-organizations-account/src/test/java/software/amazon/organizations/account/TagTestResourcesHelper.java
+++ b/aws-organizations-account/src/test/java/software/amazon/organizations/account/TagTestResourcesHelper.java
@@ -1,12 +1,12 @@
 package software.amazon.organizations.account;
 
+import com.google.common.collect.ImmutableMap;
 import software.amazon.awssdk.services.organizations.model.ListTagsForResourceResponse;
 import software.amazon.awssdk.services.organizations.model.Tag;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 public class TagTestResourcesHelper {
@@ -23,14 +23,11 @@ public class TagTestResourcesHelper {
         Tag.builder().key("Add").value("Should be added").build()
     ));
 
-    final static Set<Tag> expectedTagsToAddOrUpdate = new HashSet<Tag>(Arrays.asList(
-        Tag.builder().key("Update").value("Has been updated").build(),
-        Tag.builder().key("Add").value("Should be added").build()
-    ));
+    final static Map<String, String> defaultStackTags = ImmutableMap.of(
+            "StackTagKey1", "StackTagValue1", "StackTagKey2", "StackTagValue2");
 
-    final static Set<String> expectedTagsToRemove = new HashSet<String>(Arrays.asList(
-        "Delete"
-    ));
+    final static Map<String, String> updatedStackTags = ImmutableMap.of(
+            "StackTagKey1", "StackTagValue3", "StackTagKey4", "StackTagValue4");
 
     static ListTagsForResourceResponse buildDefaultTagsResponse() {
         return ListTagsForResourceResponse.builder()
@@ -70,21 +67,6 @@ public class TagTestResourcesHelper {
         return tagsToReturn;
     }
 
-    static Set<Tag> translateAccountTagsToOrganizationTags(Set<software.amazon.organizations.account.Tag> tags) {
-        if (tags == null) return new HashSet<>();
-
-        final Set<Tag> tagsToReturn = new HashSet<>();
-        for (software.amazon.organizations.account.Tag inputTags : tags) {
-            Tag tag = Tag.builder()
-                          .key(inputTags.getKey())
-                          .value(inputTags.getValue())
-                          .build();
-            tagsToReturn.add(tag);
-        }
-
-        return tagsToReturn;
-    }
-
     static boolean tagsEqual(Set<?> set1, Set<?> set2){
         if (set1 == null || set2 == null) {
             return false;
@@ -93,37 +75,34 @@ public class TagTestResourcesHelper {
         return set1.equals(set2);
     }
 
-    static boolean correctTagsInTagAndUntagRequests(Collection<Tag> tagsToAddOrUpdate, List<String> tagsToRemove) {
+    static boolean correctTagsInTagAndUntagRequests(Set<Tag> tagsToAddOrUpdate, Set<String> tagsToRemove) {
         boolean correctTagsInRequests = true;
 
-        Set<String> tagsToAddOrUpdateKeys = new HashSet<String>();
-        Set<String> tagsToRemoveKeys = new HashSet<String>();
-
+        Set<String> tagsToAddOrUpdateKeys = new HashSet<>();
         for (Tag tag : tagsToAddOrUpdate) {
             tagsToAddOrUpdateKeys.add(tag.key());
         }
 
-        for (String key : tagsToRemove) {
-            tagsToRemoveKeys.add(key);
-        }
-
         // Constant tag should be in neither tagsToAddOrUpdate nor tagsToRemove
-        if (tagsToAddOrUpdateKeys.contains("Constant") || tagsToRemoveKeys.contains("tagsToRemoveKeys")) {
+        if (tagsToAddOrUpdateKeys.contains("Constant") || tagsToRemove.contains("tagsToRemoveKeys")) {
             correctTagsInRequests = false;
         }
 
-        // Delete tag should be the single item in tagsToRemove
-        if (tagsToAddOrUpdateKeys.contains("Delete") || !tagsToRemoveKeys.contains("Delete") || tagsToRemoveKeys.size() != 1) {
+        // Only Delete and StackTagKey2 tags should be in tagsToRemove
+        if (tagsToAddOrUpdateKeys.contains("Delete") || tagsToAddOrUpdateKeys.contains("StackTagKey2") ||
+                !tagsToRemove.contains("Delete") || !tagsToRemove.contains("StackTagKey2") || tagsToRemove.size() != 2) {
             correctTagsInRequests = false;
         }
 
-        // Update tag should be in tagsToAddOrUpdate not tagsToRemove
-        if (!tagsToAddOrUpdateKeys.contains("Update") || tagsToRemoveKeys.contains("Update")) {
+        // Update and StackTagKey1 tags (getting updated) should be in tagsToAddOrUpdate and not in tagsToRemove
+        if (!tagsToAddOrUpdateKeys.contains("Update") || !tagsToAddOrUpdateKeys.contains("StackTagKey1") ||
+                tagsToRemove.contains("Update") || tagsToRemove.contains("StackTagKey1")) {
             correctTagsInRequests = false;
         }
 
-        // Add tag should be in tagsToAddOrUpdate not tagsToRemove
-        if (!tagsToAddOrUpdateKeys.contains("Add") || tagsToRemoveKeys.contains("Add")) {
+        // Add and StackTagKey4 tags (getting added) should be in tagsToAddOrUpdate and not in tagsToRemove
+        if (!tagsToAddOrUpdateKeys.contains("Add") || !tagsToAddOrUpdateKeys.contains("StackTagKey4") ||
+                tagsToRemove.contains("Add") || tagsToRemove.contains("StackTagKey4")) {
             correctTagsInRequests = false;
         }
 


### PR DESCRIPTION
*Description of changes:*

Adding support for stack tags in AWS Organizations Account create and update handlers by:
- Modifying handlers to handle stack tags as well during account creation and updates
- Creating a new `TagsHelper` class to centralize tag-related operations
- Adding corresponding unit tests for all account handlers

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
